### PR TITLE
Add output directory flag and generate package instead of file for single XML input

### DIFF
--- a/mule/src/test/java/TestConverter.java
+++ b/mule/src/test/java/TestConverter.java
@@ -38,7 +38,7 @@ public class TestConverter {
         }
 
         OUT.println("Generating Ballerina package...");
-        convertMuleProject("src/test/resources/projects/muleprojectdemo");
+        convertMuleProject("src/test/resources/projects/muleprojectdemo", null);
         OUT.println("________________________________________________________________");
         OUT.println("Conversion completed. Output written to " +
                 "src/test/resources/muleprojectdemo/muleprojectdemo-ballerina");


### PR DESCRIPTION
## Purpose
- Generate a Ballerina package instead of a file for single XML file input
- Add [-o|--out <output-directory>] support to mule cli

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.
