### PR TITLE
Refactor CodeGenerator to use TextDocument and add sample test

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -63,6 +63,12 @@ tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
     }
 }
 
+test {
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+}
+
 build {
     dependsOn checkstyleMain
     dependsOn spotbugsMain

--- a/common/src/main/java/common/BICodeConverter.java
+++ b/common/src/main/java/common/BICodeConverter.java
@@ -120,10 +120,7 @@ public final class BICodeConverter {
     private BallerinaModel.TextDocument fixImports(BallerinaModel.TextDocument doc) {
         // TODO: we can do this better by visiting tree and figure out types and
         //  function calls. But should be good enough for now
-        BallerinaModel.Module tmpModule = new BallerinaModel.Module("temp", List.of(doc));
-        BallerinaModel ballerinaModel = new BallerinaModel(new BallerinaModel.DefaultPackage("tmp", "tmp", "0.0.1"),
-                List.of(tmpModule));
-        SyntaxTree st = new CodeGenerator(ballerinaModel).generateBalCode();
+        SyntaxTree st = new CodeGenerator(doc).generateSyntaxTree();
         String content = st.toSourceCode();
         Pattern searchPattern = Pattern.compile("([a-zA-Z0-9]+):[a-zA-Z0-9]+");
 

--- a/common/src/main/java/common/BallerinaModel.java
+++ b/common/src/main/java/common/BallerinaModel.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -30,10 +31,12 @@ import java.util.stream.Collectors;
 
 public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules) {
 
+    // Note: not using this at the moment, but keeping it for future use
     public record DefaultPackage(String org, String name, String version) {
 
     }
 
+    // Note: not using this at the moment, but keeping it for future use
     public record Module(String name, List<TextDocument> textDocuments) {
 
     }
@@ -91,6 +94,14 @@ public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules
 
     public sealed interface TypeDesc {
 
+        record BallerinaType(String value) implements TypeDesc {
+
+            @Override
+            public String toString() {
+                return value;
+            }
+        }
+
         record MapTypeDesc(TypeDesc typeDesc) implements TypeDesc {
 
             @Override
@@ -104,14 +115,6 @@ public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules
             @Override
             public String toString() {
                 return "stream<" + valueTy + ", " + completionType + ">";
-            }
-        }
-
-        record BallerinaType(String value) implements TypeDesc {
-
-            @Override
-            public String toString() {
-                return value;
             }
         }
 
@@ -283,8 +286,12 @@ public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules
     }
 
     public record Service(String basePath, List<String> listenerRefs, Optional<Function> initFunc,
-                          List<Resource> resources, List<Function> functions, List<String> pathParams,
-                          List<String> queryParams, List<ObjectField> fields) {
+                          List<Resource> resources, List<Function> functions,
+                          List<ObjectField> fields) {
+        public Service(String basePath, String listenerRef, List<Resource> resources) {
+            this(basePath, Collections.singletonList(listenerRef), Optional.empty(), resources,
+                    Collections.emptyList(), Collections.emptyList());
+        }
     }
 
     public record ObjectField(TypeDesc type, String name) {
@@ -309,19 +316,14 @@ public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules
     }
 
     public record Resource(String resourceMethodName, String path, List<Parameter> parameters,
-                           Optional<String> returnType, List<Statement> body) {
+                           Optional<TypeDesc> returnType, List<Statement> body) {
     }
 
     public record Function(Optional<String> visibilityQualifier, String functionName, List<Parameter> parameters,
-                           Optional<String> returnType, FunctionBody body) {
+                           Optional<TypeDesc> returnType, FunctionBody body) {
 
         public Function(String funcName, List<Parameter> parameters, TypeDesc returnType,
                         List<Statement> body) {
-            this(Optional.empty(), funcName, parameters, Optional.of(returnType.toString()),
-                    new BlockFunctionBody(body));
-        }
-
-        public Function(String funcName, List<Parameter> parameters, String returnType, List<Statement> body) {
             this(Optional.empty(), funcName, parameters, Optional.of(returnType), new BlockFunctionBody(body));
         }
 
@@ -358,6 +360,14 @@ public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules
     }
 
     public sealed interface Expression {
+
+        record BallerinaExpression(String expr) implements Expression {
+
+            @Override
+            public String toString() {
+                return expr;
+            }
+        }
 
         record Not(Expression expression) implements Expression {
 
@@ -546,17 +556,17 @@ public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules
                 return condition + " ? " + ifTrue + " : " + ifFalse;
             }
         }
-
-        record BallerinaExpression(String expr) implements Expression {
-
-            @Override
-            public String toString() {
-                return expr;
-            }
-        }
     }
 
     public sealed interface Statement {
+
+        record BallerinaStatement(String stmt) implements Statement {
+
+            @Override
+            public String toString() {
+                return stmt;
+            }
+        }
 
         record CallStatement(Expression callExpr) implements Statement {
 
@@ -647,14 +657,6 @@ public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules
             @Override
             public String toString() {
                 return ref + " = " + value + ";";
-            }
-        }
-
-        record BallerinaStatement(String stmt) implements Statement {
-
-            @Override
-            public String toString() {
-                return stmt;
             }
         }
 

--- a/common/src/main/java/common/CodeGenerator.java
+++ b/common/src/main/java/common/CodeGenerator.java
@@ -157,7 +157,7 @@ public class CodeGenerator {
         if (textDocument.Comments().isEmpty()) {
             eofLeadingMinutiae = NodeFactory.createEmptyMinutiaeList();
         } else {
-            String comments = String.join("", textDocument.Comments());
+            String comments = String.join("\n", textDocument.Comments());
             eofLeadingMinutiae = parseLeadingMinutiae(comments);
         }
 

--- a/common/src/test/java/common/TestIRCodeGen.java
+++ b/common/src/test/java/common/TestIRCodeGen.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package common;
+
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static common.ConversionUtils.stmtFrom;
+import static common.ConversionUtils.typeFrom;
+
+public class TestIRCodeGen {
+
+    @Test
+    public void testSimpleIRToBalCodeGen() {
+        final String listenerName = "myHttpListener";
+        final String queryParamName = "name";
+
+        HashSet<BallerinaModel.Import> imports = new HashSet<>();
+
+        // Create a http listener
+        BallerinaModel.Listener httpListener = new BallerinaModel.Listener(BallerinaModel.ListenerType.HTTP,
+                listenerName, "9090", "0.0.0.0");
+        imports.add(new BallerinaModel.Import("ballerina", "http"));
+
+        // Create resource body statements
+        List<BallerinaModel.Statement> resourceBody = new ArrayList<>();
+        resourceBody.add(stmtFrom("log:printInfo(\"Received request for greeting with name: \" + %s);"
+                .formatted(queryParamName)));
+        imports.add(new BallerinaModel.Import("ballerina", "log"));
+        resourceBody.add(stmtFrom("json payload = {\"message\": \"Hello \" + %s};".formatted(queryParamName)));
+        resourceBody.add(stmtFrom("return payload;"));
+
+        // Create simple get resource
+        BallerinaModel.Resource getResource = new BallerinaModel.Resource(
+                "get", "hello",
+                Collections.singletonList(new BallerinaModel.Parameter(queryParamName, typeFrom("string"))),
+                Optional.of(typeFrom("json")), resourceBody);
+
+        // Create a service
+        BallerinaModel.Service service = new BallerinaModel.Service("/greetings", listenerName,
+                Collections.singletonList(getResource));
+
+        // Comments
+        List<String> comments = new ArrayList<>();
+        comments.add("\n");
+        comments.add("// This Ballerina service listens on port 9090 and provides a resource to greet users.");
+        comments.add("// e.g. curl -X GET http://localhost:9090/greetings/hello?name=John");
+
+        // Create new TextDocument
+        BallerinaModel.TextDocument textDocument = new BallerinaModel.TextDocument(
+                "demo.bal",
+                imports.stream().toList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.singletonList(httpListener),
+                Collections.singletonList(service),
+                Collections.emptyList(),
+                comments);
+
+        SyntaxTree syntaxTree = new CodeGenerator(textDocument).generateSyntaxTree();
+        String generatedCode = syntaxTree.toSourceCode();
+        assertGeneratedCode(generatedCode, "src/test/resources/common/greetings_http_service.bal");
+    }
+
+    private static void assertGeneratedCode(String actualCode, String pathToExpectedCode) {
+        String expectedCode = getSourceText(Path.of(pathToExpectedCode));
+        Assert.assertEquals(actualCode, expectedCode,
+                "Generated Ballerina code does not match the expected code.");
+    }
+
+    /**
+     * Returns Ballerina source code in the given file as a {@code String}.
+     *
+     * @param sourceFilePath Path to the ballerina file
+     * @return source code as a {@code String}
+     */
+    private static String getSourceText(Path sourceFilePath) {
+        try {
+            return Files.readString(sourceFilePath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/common/src/test/resources/common/greetings_http_service.bal
+++ b/common/src/test/resources/common/greetings_http_service.bal
@@ -1,0 +1,15 @@
+import ballerina/http;
+import ballerina/log;
+
+public listener http:Listener myHttpListener = new (9090);
+
+service /greetings on myHttpListener {
+    resource function get hello(string name) returns json {
+        log:printInfo("Received request for greeting with name: " + name);
+        json payload = {"message": "Hello " + name};
+        return payload;
+    }
+}
+
+// This Ballerina service listens on port 9090 and provides a resource to greet users.
+// e.g. curl -X GET http://localhost:9090/greetings/hello?name=John

--- a/common/src/test/resources/testng.xml
+++ b/common/src/test/resources/testng.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<suite name="Suite" time-out="120000">
+    <test name="Common Tests">
+        <packages>
+            <package name="common"/>
+        </packages>
+    </test>
+</suite>

--- a/mule/src/main/java/mule/MuleConverter.java
+++ b/mule/src/main/java/mule/MuleConverter.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
 
 import static mule.HtmlReportWriter.writeHtmlReport;
 import static mule.MuleToBalConverter.convertProjectXMLFileToBallerina;
-import static mule.MuleToBalConverter.createBallerinaModel;
+import static mule.MuleToBalConverter.createTextDocument;
 import static mule.MuleToBalConverter.createContextTypeDefns;
 
 public class MuleConverter {
@@ -275,11 +275,12 @@ public class MuleConverter {
         createContextTypeDefns(sharedProjectData);
 
         Path targetFilePath = Paths.get(targetFolderPath, "internal-types.bal");
-        BallerinaModel ballerinaModel = createBallerinaModel(sharedProjectData.contextTypeDefImports.stream().toList(),
+        BallerinaModel.TextDocument textDocument =
+                createTextDocument("internal-types", sharedProjectData.contextTypeDefImports.stream().toList(),
                 sharedProjectData.contextTypeDefMap.values().stream().toList(), Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-        SyntaxTree syntaxTree = new CodeGenerator(ballerinaModel).generateBalCode();
+        SyntaxTree syntaxTree = new CodeGenerator(textDocument).generateSyntaxTree();
         try {
             Files.writeString(targetFilePath, syntaxTree.toSourceCode());
         } catch (IOException e) {

--- a/mule/src/main/java/mule/dataweave/converter/BallerinaVisitor.java
+++ b/mule/src/main/java/mule/dataweave/converter/BallerinaVisitor.java
@@ -132,7 +132,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
         }
         this.dwContext.functionNames.add(methodName);
         this.data.functions.add(new BallerinaModel.Function(Optional.empty(), methodName,
-                dwContext.currentScriptContext.params, Optional.of(outputType),
+                dwContext.currentScriptContext.params, Optional.of(typeFrom(outputType)),
                 new BallerinaModel.BlockFunctionBody(dwContext.currentScriptContext.statements)));
         return null;
     }
@@ -651,7 +651,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
         data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.PARSE_DATE_TIME,
                 List.of(new BallerinaModel.Parameter("date", BAL_HANDLE_TYPE),
                         new BallerinaModel.Parameter("formatter", BAL_HANDLE_TYPE)),
-                Optional.of(LexerTerminals.HANDLE), body));
+                Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
 
         // create toInstant() function
         data.utilFunctions.add(DWUtils.TO_INSTANT);
@@ -661,14 +661,14 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
         data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.TO_INSTANT,
                 List.of(new BallerinaModel.Parameter("localDateTime", BAL_HANDLE_TYPE),
                         new BallerinaModel.Parameter("zoneOffset", BAL_HANDLE_TYPE)),
-                Optional.of(LexerTerminals.HANDLE), body));
+                Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
 
         // create utcZoneOffset() function
         data.utilFunctions.add(DWUtils.UTC_ZONE_OFFSET);
         body = new BallerinaModel.ExternFunctionBody("java.time.ZoneOffset",
                 Optional.of("UTC"), "@java:FieldGet", Optional.empty());
         data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.UTC_ZONE_OFFSET,
-                List.of(), Optional.of(LexerTerminals.HANDLE), body));
+                List.of(), Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
 
         // create dateFromFormattedString() function
         data.utilFunctions.add(DWUtils.GET_DATE_FROM_FORMATTED_STRING);
@@ -686,7 +686,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
         statements.add(new BallerinaStatement("return check time:utcFromString(" +
                 "toInstant(localDateTime, UTC()).toString());"));
         return new BallerinaModel.Function(Optional.of("public"),
-                DWUtils.GET_DATE_FROM_FORMATTED_STRING, params, Optional.of("time:Utc|error"),
+                DWUtils.GET_DATE_FROM_FORMATTED_STRING, params, Optional.of(typeFrom("time:Utc|error")),
                 new BallerinaModel.BlockFunctionBody(statements));
     }
 
@@ -701,7 +701,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
         data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.FORMAT_DATE_TIME,
                 List.of(new BallerinaModel.Parameter("dateTime", BAL_HANDLE_TYPE),
                         new BallerinaModel.Parameter("formatter", BAL_HANDLE_TYPE)),
-                Optional.of(LexerTerminals.HANDLE), body));
+                Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
 
         // create formatDateTimeString() function
         if (!data.utilFunctions.contains(DWUtils.GET_DATE_TIME_FORMATTER)) {
@@ -713,7 +713,8 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
         body = new BallerinaModel.ExternFunctionBody("java.time.ZoneId",
                 Optional.of("of"), "@java:Method", Optional.of(List.of("java.lang.String")));
         data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.GET_ZONE_ID,
-                List.of(new BallerinaModel.Parameter("zoneId", BAL_HANDLE_TYPE)), Optional.of(LexerTerminals.HANDLE),
+                List.of(new BallerinaModel.Parameter("zoneId", BAL_HANDLE_TYPE)),
+                Optional.of(typeFrom(LexerTerminals.HANDLE)),
                 body));
 
         // create getDateTime() function
@@ -724,7 +725,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
         data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.GET_DATE_TIME,
                 List.of(new BallerinaModel.Parameter("instant", BAL_HANDLE_TYPE),
                         new BallerinaModel.Parameter("zoneId", BAL_HANDLE_TYPE)),
-                Optional.of(LexerTerminals.HANDLE), body));
+                Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
 
         // create parseInstant() function
         data.utilFunctions.add(DWUtils.PARSE_INSTANT);
@@ -732,7 +733,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
                 Optional.of("parse"), "@java:Method", Optional.empty());
         data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.PARSE_INSTANT,
                 List.of(new BallerinaModel.Parameter("instant", BAL_HANDLE_TYPE)),
-                Optional.of(LexerTerminals.HANDLE), body));
+                Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
 
         // create getFormattedStringFromDate() function
         data.utilFunctions.add(DWUtils.GET_FORMATTED_STRING_FROM_DATE);
@@ -746,7 +747,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
         statements.add(new BallerinaStatement("return formatDateTime(localDateTime, " +
                 "getDateTimeFormatter(java:fromString(format))).toString();"));
         return new BallerinaModel.Function(Optional.of("public"), DWUtils.GET_FORMATTED_STRING_FROM_DATE,
-                params, Optional.of(LexerTerminals.STRING), new BallerinaModel.BlockFunctionBody(statements));
+                params, Optional.of(typeFrom(LexerTerminals.STRING)), new BallerinaModel.BlockFunctionBody(statements));
     }
 
     private void generateGetDateTimeFormatter() {
@@ -755,8 +756,8 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
                 "java.time.format.DateTimeFormatter",
                 Optional.of("ofPattern"), "@java:Method", Optional.of(List.of("java.lang.String")));
         data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.GET_DATE_TIME_FORMATTER,
-                List.of(new BallerinaModel.Parameter("format", BAL_HANDLE_TYPE)), Optional.of(LexerTerminals.HANDLE),
-                body));
+                List.of(new BallerinaModel.Parameter("format", BAL_HANDLE_TYPE)),
+                Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
     }
 
     private BallerinaModel.Function getIntToStringFunction() {
@@ -766,7 +767,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
                     Optional.empty(), "@java:Constructor", Optional.empty());
             data.functions.add(new BallerinaModel.Function(Optional.of("public"), DWUtils.NEW_DECIMAL_FORMAT,
                     List.of(new BallerinaModel.Parameter("format", BAL_HANDLE_TYPE)),
-                    Optional.of(LexerTerminals.HANDLE), body));
+                    Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
         }
         if (!data.utilFunctions.contains(DWUtils.GET_FORMATTED_STRING_FROM_NUMBER)) {
             data.utilFunctions.add(DWUtils.GET_FORMATTED_STRING_FROM_NUMBER);
@@ -777,7 +778,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
                     List.of(new BallerinaModel.Parameter("formatObject", BAL_HANDLE_TYPE),
                             new BallerinaModel.Parameter("value", BAL_INT_TYPE,
                                     Optional.empty())),
-                    Optional.of(LexerTerminals.HANDLE), body));
+                    Optional.of(typeFrom(LexerTerminals.HANDLE)), body));
         }
         List<BallerinaModel.Parameter> params = new ArrayList<>();
         params.add(new BallerinaModel.Parameter("intValue", BAL_INT_TYPE));
@@ -790,7 +791,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
                 DWUtils.GET_FORMATTED_STRING_FROM_NUMBER + "(formatObj, intValue);"));
         statements.add(new BallerinaStatement("return stringResult.toString();"));
         return new BallerinaModel.Function(Optional.of("public"), DWUtils.INT_TO_STRING, params,
-                Optional.of(LexerTerminals.STRING), new BallerinaModel.BlockFunctionBody(statements));
+                Optional.of(typeFrom(LexerTerminals.STRING)), new BallerinaModel.BlockFunctionBody(statements));
     }
 
     @Override
@@ -865,7 +866,7 @@ public class BallerinaVisitor extends DataWeaveBaseVisitor<Void> {
 
     private BallerinaModel.Function getCurrentTimeStringFunction() {
         return new BallerinaModel.Function(Optional.of("public"), DWUtils.GET_CURRENT_TIME_STRING, new ArrayList<>(),
-                Optional.of(LexerTerminals.STRING), new BallerinaModel.BlockFunctionBody(List.of(
+                Optional.of(typeFrom(LexerTerminals.STRING)), new BallerinaModel.BlockFunctionBody(List.of(
                         new BallerinaStatement("return time:utcToString(time:utcNow());"))));
     }
 

--- a/tibco/src/main/java/tibco/converter/ProcessConverter.java
+++ b/tibco/src/main/java/tibco/converter/ProcessConverter.java
@@ -80,9 +80,7 @@ public class ProcessConverter {
         assert startActivity instanceof HttpEventSource;
         String name = baseName(((HttpEventSource) startActivity).sharedChannel());
         VariableReference listenerRef = cx.getProjectContext().httpListener(name);
-        return new BallerinaModel.Service("", List.of(listenerRef.varName()), Optional.empty(), List.of(resource),
-                List.of(), List.of(), List.of(), List.of());
-
+        return new BallerinaModel.Service("", listenerRef.varName(), List.of(resource));
     }
 
     static void addProcessClient(ProcessContext cx, TibcoModel.Process.ExplicitTransitionGroup group,
@@ -129,7 +127,7 @@ public class ProcessConverter {
                 body.add(new VarAssignStatement(resultDecl.ref(), xsltTransform(cx, resultDecl.ref(), binding))));
         body.add(new Return<>(resultDecl.ref()));
         return new BallerinaModel.Resource("'default[string... path]", "",
-                List.of(parameter), Optional.of("xml"), body);
+                List.of(parameter), Optional.of(XML), body);
     }
 
     static BallerinaModel.TextDocument convertBody(ProcessContext cx, TibcoModel.Process process,
@@ -289,7 +287,7 @@ public class ProcessConverter {
         return new BallerinaModel.Function(errorHandlerFunction,
                 List.of(new Parameter("err", ERROR),
                         context),
-                XML.toString(), body);
+                XML, body);
     }
 
     private static BallerinaModel.Function generateStartFunction(ProcessContext cx) {
@@ -327,7 +325,7 @@ public class ProcessConverter {
         return new BallerinaModel.Function(startFuncData.name(),
                 List.of(new Parameter(inputVar.varName(), inputType),
                         new Parameter(new TypeDesc.MapTypeDesc(XML), params.varName(), exprFrom("{}"))),
-                returnType.toString(), body);
+                returnType, body);
     }
 
     private static BallerinaModel.Function generateProcessFunction(ProcessContext cx) {
@@ -450,7 +448,7 @@ public class ProcessConverter {
         return new BallerinaModel.Function(errorHandlerFunction,
                 List.of(new Parameter("err", ERROR),
                         context),
-                XML.toString(), body);
+                XML, body);
     }
 
     private static VariableReference generateActivityFlowFunctionInner(

--- a/tibco/src/main/java/tibco/converter/ProjectContext.java
+++ b/tibco/src/main/java/tibco/converter/ProjectContext.java
@@ -117,7 +117,7 @@ public class ProjectContext {
         String functionName = "toXML";
         utilityFunctions.add(new BallerinaModel.Function(functionName,
                 List.of(new BallerinaModel.Parameter("data", new BallerinaModel.TypeDesc.MapTypeDesc(ANYDATA))),
-                new UnionTypeDesc(List.of(ERROR, XML)).toString(),
+                new UnionTypeDesc(List.of(ERROR, XML)),
                 List.of(new Return<>(
                         Optional.of(new FunctionCall("xmldata:toXml",
                                 new String[]{"data"}))))));

--- a/tibco/src/main/java/tibco/converter/TibcoConverter.java
+++ b/tibco/src/main/java/tibco/converter/TibcoConverter.java
@@ -97,10 +97,10 @@ public class TibcoConverter {
             BallerinaModel.Module biModule = new BICodeConverter().convert(result.module());
             textDocuments = biModule.textDocuments();
         }
-        BallerinaModel.DefaultPackage balPackage = new BallerinaModel.DefaultPackage("tibco", "sample", "0.1");
+
         for (BallerinaModel.TextDocument textDocument : textDocuments) {
             try {
-                writeTextDocument(result.module(), balPackage, textDocument, targetDir);
+                writeTextDocument(textDocument, targetDir);
             } catch (IOException e) {
                 logger().log(Level.SEVERE, "Failed to create output file" + textDocument.documentName(), e);
             }
@@ -124,12 +124,9 @@ public class TibcoConverter {
         logger().info("Created analysis report at: " + reportFilePath);
     }
 
-    private static void writeTextDocument(BallerinaModel.Module module, BallerinaModel.DefaultPackage balPackage,
-                                          BallerinaModel.TextDocument textDocument, Path targetDir) throws IOException {
-        BallerinaModel.Module tmpModule = new BallerinaModel.Module(module.name(), List.of(textDocument));
-        BallerinaModel ballerinaModel = new BallerinaModel(balPackage, List.of(tmpModule));
+    private static void writeTextDocument(BallerinaModel.TextDocument textDocument, Path targetDir) throws IOException {
         String fileName = textDocument.documentName();
-        SyntaxTree st = new CodeGenerator(ballerinaModel).generateBalCode();
+        SyntaxTree st = new CodeGenerator(textDocument).generateSyntaxTree();
         writeASTToFile(targetDir, fileName, st);
     }
 

--- a/tibco/src/main/java/tibco/converter/TypeConverter.java
+++ b/tibco/src/main/java/tibco/converter/TypeConverter.java
@@ -140,9 +140,7 @@ class TypeConverter {
         String apiPath = portType.apiPath();
         List<BallerinaModel.Resource> resources = List
                 .of(convertOperation(cx, apiPath, messageTypes, portType.operation(), wsdlNamespaces, messages));
-        List<String> listenerRefs = List.of(cx.getDefaultHttpListenerRef());
-        return new BallerinaModel.Service(basePath, listenerRefs, Optional.empty(), resources, List.of(), List.of(),
-                List.of(), List.of());
+        return new BallerinaModel.Service(basePath, cx.getDefaultHttpListenerRef(), resources);
     }
 
     private static BallerinaModel.Resource convertOperation(ProcessContext cx, String apiPath,
@@ -180,7 +178,7 @@ class TypeConverter {
                 new FunctionCall(cx.getProcessStartFunction().name(), startFunctionArgs))));
 
         return new BallerinaModel.Resource(resourceMethodName, path, resourceMethodParameter.stream().toList(),
-                Optional.of(returnType.toString()), body);
+                Optional.of(returnType), body);
     }
 
     private static ParamInitResult dataBindingForBody(ProcessContext cx,


### PR DESCRIPTION
## Purpose
$subject.

- Add an IR to CodeGen test case to refer
- Fixed String type usage instead of TypeDesc in Resource and Function records
- Refactor CodeGenerator to use TextDocument instance instead of BallerinaModel

Fixes #120

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.
