### PR TITLE
Fix TIBCO tool crashes caused by start activity without name

### DIFF
--- a/cli-tibco/src/main/ballerina/tool-bi-migrate-tibco/Ballerina.toml
+++ b/cli-tibco/src/main/ballerina/tool-bi-migrate-tibco/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "wso2"
 name = "tool_migrate_tibco"
-version = "1.2.6"
+version = "1.2.7"
 distribution = "2201.12.3"
 keywords = ["migrate-tibco", "tibco-migrate", "tibco", "migrator"]

--- a/cli-tibco/src/main/ballerina/tool-bi-migrate-tibco/Dependencies.toml
+++ b/cli-tibco/src/main/ballerina/tool-bi-migrate-tibco/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.6"
+distribution-version = "2201.11.0"
 
 [[package]]
 org = "wso2"
 name = "tool_migrate_tibco"
-version = "1.2.6"
+version = "1.2.7"
 modules = [
 	{org = "wso2", packageName = "tool_migrate_tibco", moduleName = "tool_migrate_tibco"}
 ]

--- a/common/src/main/java/common/BallerinaModel.java
+++ b/common/src/main/java/common/BallerinaModel.java
@@ -282,7 +282,8 @@ public record BallerinaModel(DefaultPackage defaultPackage, List<Module> modules
             STRING("string"),
             HANDLE("handle"),
             READONLY("readonly"),
-            XML("xml");
+            XML("xml"),
+            BYTE("byte");
 
             private final String name;
 

--- a/common/src/main/java/common/CodeGenerator.java
+++ b/common/src/main/java/common/CodeGenerator.java
@@ -177,7 +177,10 @@ public class CodeGenerator {
         }
 
         SyntaxTree syntaxTree = createSyntaxTree(importDecls, moduleMemberDecls, eofLeadingMinutiae);
-        syntaxTree = formatSyntaxTree(syntaxTree);
+        // This is to a hack to avoid OOM when we give huge projects
+        if (System.getenv("BAL_MIGRATE_SKIP_FORMATTING") == null) {
+            syntaxTree = formatSyntaxTree(syntaxTree);
+        }
         return syntaxTree;
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,6 @@ gsonVersion=2.13.1
 snakeYamlVersion=2.0
 
 # tool properties
-tibcoVersion=1.2.7
+tibcoVersion=1.2.8-SNAPSHOT
 muleVersion=1.2.0
 logicAppsVersion=1.0.0-SNAPSHOT

--- a/tibco/src/main/java/tibco/converter/ActivityContext.java
+++ b/tibco/src/main/java/tibco/converter/ActivityContext.java
@@ -118,7 +118,7 @@ public class ActivityContext implements LoggingContext {
         return processContext.getRenderJsonAsXMLFunction(type);
     }
 
-    BallerinaModel.Expression.VariableReference getProcessClient(String processName) {
+    Optional<BallerinaModel.Expression.VariableReference> getProcessClient(String processName) {
         return processContext.getProcessClient(processName);
     }
 

--- a/tibco/src/main/java/tibco/converter/ActivityConverter.java
+++ b/tibco/src/main/java/tibco/converter/ActivityConverter.java
@@ -56,7 +56,6 @@ import tibco.model.Scope.Flow.Activity.Reply;
 import tibco.model.Scope.Flow.Activity.Throw;
 import tibco.model.Scope.Flow.Activity.UnhandledActivity;
 import tibco.model.ValueSource;
-import tibco.model.XSD;
 import tibco.xslt.AddMissingParameters;
 import tibco.xslt.IgnoreRootWrapper;
 import tibco.xslt.ReplaceDotAccessWithXPath;
@@ -358,7 +357,8 @@ final class ActivityConverter {
 
             if (!noneValues.isEmpty()) {
                     String warningMessage = String.format(
-                                    "WARNING: JMS Activity '%s' has unsupported values for SessionAttributes: %s. Most likely they were TIBCO configuration values",
+                                    "WARNING: JMS Activity '%s' has unsupported values for SessionAttributes: %s. " +
+                                    "Most likely they were TIBCO configuration values",
                                     activity.name(), String.join(", ", noneValues));
                     cx.log(WARN, warningMessage);
                     cx.registerPartiallySupportedActivity(activity);

--- a/tibco/src/main/java/tibco/converter/ActivityConverter.java
+++ b/tibco/src/main/java/tibco/converter/ActivityConverter.java
@@ -373,6 +373,11 @@ final class ActivityConverter {
                 JMSConnectionData.from(cx, cx.getJmsResource(jmsQueueSendActivity.connectionReference()));
         body.add(jmsConnectionData.connection);
         body.add(jmsConnectionData.session);
+        if (!jmsQueueSendActivity.permittedMessageType().equalsIgnoreCase("Text")) {
+            body.add(new Comment(
+                    "WARNING: Unexpected message type: %s Only Text messages are supported in JMSQueueSendActivity"
+                            .formatted(jmsQueueSendActivity.permittedMessageType())));
+        }
         body.add(new Comment("WARNING: using default destination configuration"));
         VarDeclStatment producer = new VarDeclStatment(ConversionUtils.Constants.JMS_MESSAGE_PRODUCER,
                 cx.getAnnonVarName(),

--- a/tibco/src/main/java/tibco/converter/Intrinsics.java
+++ b/tibco/src/main/java/tibco/converter/Intrinsics.java
@@ -228,7 +228,7 @@ public enum Intrinsics {
     RENDER_JSON_AS_XML(
             "renderJSONAsXML",
             """
-                    function renderJSONAsXML(json value, string? namespace, string typeName) returns xml|error {
+                    function renderJSONAsXML(json value, string? namespace, string? typeName) returns xml|error {
                         anydata body;
                         if (value is map<json>) {
                             xml acum = xml ``;
@@ -240,7 +240,8 @@ public enum Intrinsics {
                             body = value;
                         }
 
-                        string rep = string `<${typeName}>${body.toString()}</${typeName}>`;
+                        string rep = typeName == () ? body.toString() :
+                            string `<${typeName}>${body.toString()}</${typeName}>`;
                         xml result = check xml:fromString(rep);
                         if (namespace == ()) {
                             return result;

--- a/tibco/src/main/java/tibco/converter/ProcessContext.java
+++ b/tibco/src/main/java/tibco/converter/ProcessContext.java
@@ -150,7 +150,7 @@ public class ProcessContext implements ContextWithFile, LoggingContext {
         projectContext.registerProcessClient(baseName(process.name()).toLowerCase(), name);
     }
 
-    public Expression.VariableReference getProcessClient(String processName) {
+    public Optional<Expression.VariableReference> getProcessClient(String processName) {
         return projectContext.getProcessClient(baseName(processName).toLowerCase());
     }
 

--- a/tibco/src/main/java/tibco/converter/ProcessConverter.java
+++ b/tibco/src/main/java/tibco/converter/ProcessConverter.java
@@ -231,7 +231,7 @@ public class ProcessConverter {
         String listenerName = "jms" + ConversionUtils.sanitizes(jmsQueueEventSource.name()) + "Listener";
         String initialContextFactory = jmsResource.namingEnvironment().namingInitialContextFactory();
         String providerUrl = jmsResource.namingEnvironment().providerURL();
-        String destinationName = jmsQueueEventSource.sessionAttributes().destination();
+        String destinationName = jmsQueueEventSource.sessionAttributes().destination().orElse("Default queue");
 
         BallerinaModel.Listener.JMSListener listener =
                 new BallerinaModel.Listener.JMSListener(listenerName, initialContextFactory, providerUrl,

--- a/tibco/src/main/java/tibco/converter/ProjectContext.java
+++ b/tibco/src/main/java/tibco/converter/ProjectContext.java
@@ -486,8 +486,8 @@ public class ProjectContext implements LoggingContext {
         return "proj_annon_var" + annonVarCount++;
     }
 
-    public VariableReference getProcessClient(String processName) {
-        return new VariableReference(Objects.requireNonNull(processClients.get(processName)));
+    public Optional<VariableReference> getProcessClient(String processName) {
+        return Optional.ofNullable(processClients.get(processName)).map(VariableReference::new);
     }
 
     public String getToJsonFunction() {

--- a/tibco/src/main/java/tibco/converter/RenderJSONAsXML.java
+++ b/tibco/src/main/java/tibco/converter/RenderJSONAsXML.java
@@ -22,7 +22,6 @@ import common.BallerinaModel;
 
 public record RenderJSONAsXML(String type) implements ComptimeFunction {
 
-    // FIXME: special case map json
     private static final String NAME = "renderJsonAs%sXML";
     private static final String FUNCTION = """
             function %1$s(xml value) returns xml|error {

--- a/tibco/src/main/java/tibco/converter/RenderJSONAsXML.java
+++ b/tibco/src/main/java/tibco/converter/RenderJSONAsXML.java
@@ -18,7 +18,11 @@
 
 package tibco.converter;
 
+import common.BallerinaModel;
+
 public record RenderJSONAsXML(String type) implements ComptimeFunction {
+
+    // FIXME: special case map json
     private static final String NAME = "renderJsonAs%sXML";
     private static final String FUNCTION = """
             function %1$s(xml value) returns xml|error {
@@ -29,13 +33,26 @@ public record RenderJSONAsXML(String type) implements ComptimeFunction {
             }
             """;
 
+    private static final String FUNCTION_IGNORE_NAMESPACE = """
+            function %1$s(xml value) returns xml|error {
+                string jsonString = (value/<jsonString>).data();
+                map<json> jsonValue = check jsondata:parseString(jsonString);
+                string? namespace = ();
+                return %3$s(jsonValue, namespace, ());
+            }
+            """;
+
     @Override
     public String functionName() {
-        return NAME.formatted(type);
+        return NAME.formatted(ConversionUtils.sanitizes(type));
     }
 
     @Override
     public String intrinsify() {
+        if (type.equals(new BallerinaModel.TypeDesc.MapTypeDesc(BallerinaModel.TypeDesc.BuiltinType.JSON).toString())) {
+            // Special case for map<json>
+            return FUNCTION_IGNORE_NAMESPACE.formatted(functionName(), type, Intrinsics.RENDER_JSON_AS_XML.name);
+        }
         return FUNCTION.formatted(functionName(), type, Intrinsics.RENDER_JSON_AS_XML.name);
     }
 }

--- a/tibco/src/main/java/tibco/model/Process5.java
+++ b/tibco/src/main/java/tibco/model/Process5.java
@@ -384,8 +384,21 @@ public record Process5(String name, Collection<NameSpace> nameSpaces,
             }
 
             record XMLParseActivity(Element element, String name,
-                    InputBinding inputBinding, String fileName)
+                                    InputBinding inputBinding, InputStyle inputStyle, String fileName)
                     implements ExplicitTransitionGroup.InlineActivity {
+
+                public enum InputStyle {
+                    TEXT,
+                    BINARY;
+
+                    public static InputStyle from(String s) {
+                        return switch (s.toLowerCase()) {
+                            case "text" -> TEXT;
+                            case "binary" -> BINARY;
+                            default -> throw new IllegalArgumentException("Unknown XMLParseActivity input style: " + s);
+                        };
+                    }
+                }
 
                 public XMLParseActivity {
                     assert inputBinding != null;

--- a/tibco/src/main/java/tibco/model/Process5.java
+++ b/tibco/src/main/java/tibco/model/Process5.java
@@ -640,8 +640,8 @@ public record Process5(String name, Collection<NameSpace> nameSpaces,
                                    ConfigurableHeaders configurableHeaders,
                     String connectionReference, String fileName) {
 
-                public record SessionAttributes(boolean transacted, int acknowledgeMode, int maxSessions,
-                                                String destination) {
+                public record SessionAttributes(Optional<Boolean> transacted, Optional<Integer> acknowledgeMode,
+                        Optional<Integer> maxSessions, Optional<String> destination) {
 
                 }
 

--- a/tibco/src/main/java/tibco/model/Process5.java
+++ b/tibco/src/main/java/tibco/model/Process5.java
@@ -124,7 +124,7 @@ public record Process5(String name, Collection<NameSpace> nameSpaces,
                 return this;
             }
             if (activities.isEmpty()) {
-                return this;
+                throw new IllegalStateException("Empty process without activities");
             }
             String startActivityName = transitions.stream()
                     .filter(transition -> transition.from().equalsIgnoreCase("start"))

--- a/tibco/src/main/java/tibco/model/Process5.java
+++ b/tibco/src/main/java/tibco/model/Process5.java
@@ -246,7 +246,8 @@ public record Process5(String name, Collection<NameSpace> nameSpaces,
             }
 
             record JSONRender(Element element, String name, InputBinding inputBinding,
-                              XSD targetType, String fileName) implements ExplicitTransitionGroup.InlineActivity {
+                              Optional<XSD> targetType, String fileName)
+                    implements ExplicitTransitionGroup.InlineActivity {
 
                 public JSONRender {
                     assert inputBinding != null;
@@ -264,7 +265,8 @@ public record Process5(String name, Collection<NameSpace> nameSpaces,
             }
 
             record JSONParser(Element element, String name, InputBinding inputBinding,
-                              XSD targetType, String fileName) implements ExplicitTransitionGroup.InlineActivity {
+                              Optional<XSD> targetType, String fileName)
+                    implements ExplicitTransitionGroup.InlineActivity {
 
                 public JSONParser {
                     assert inputBinding != null;

--- a/tibco/src/main/java/tibco/parser/XmlToTibcoModelParser.java
+++ b/tibco/src/main/java/tibco/parser/XmlToTibcoModelParser.java
@@ -451,11 +451,11 @@ public final class XmlToTibcoModelParser {
                 cx.fileName());
     }
 
-    private static @NotNull XSD getJSONActivityTarget(Element element) {
-        Element config = getFirstChildWithTag(element, "config");
-        Element activityOutputEditor = getFirstChildWithTag(config, "ActivityOutputEditor");
-        Element xsdElement = getFirstChildWithTag(activityOutputEditor, "element");
-        return parseXSD(xsdElement);
+    private static @NotNull Optional<XSD> getJSONActivityTarget(Element element) {
+        return tryGetFirstChildWithTag(element, "config")
+                .flatMap(config -> tryGetFirstChildWithTag(config, "ActivityOutputEditor"))
+                .flatMap(activityOutputEditor -> tryGetFirstChildWithTag(activityOutputEditor, "element"))
+                .map(XmlToTibcoModelParser::parseXSD);
     }
 
     private static XSD parseXSD(Element element) {

--- a/tibco/src/main/java/tibco/parser/XmlToTibcoModelParser.java
+++ b/tibco/src/main/java/tibco/parser/XmlToTibcoModelParser.java
@@ -1897,9 +1897,6 @@ public final class XmlToTibcoModelParser {
     private static InlineActivity.JMSActivityBase parseJMSActivityInner(ProcessContext cx, Element element, String name,
             Flow.Activity.InputBinding inputBinding) {
         String permittedMessageType = getInlineActivityConfigValue(element, "PermittedMessageType");
-        if (!permittedMessageType.equals("Text")) {
-            throw new UnsupportedOperationException("Unsupported permitted message type: " + permittedMessageType);
-        }
         Element config = getFirstChildWithTag(element, "config");
         InlineActivity.JMSActivityBase.SessionAttributes sessionAttributes = parseJMSSessionAttributes(config);
         InlineActivity.JMSActivityBase.ConfigurableHeaders configurableHeaders = parseJMSConfigurableHeaders(config);

--- a/tibco/src/main/java/tibco/parser/XmlToTibcoModelParser.java
+++ b/tibco/src/main/java/tibco/parser/XmlToTibcoModelParser.java
@@ -578,11 +578,9 @@ public final class XmlToTibcoModelParser {
 
     private static XMLParseActivity parseXmlParseActivity(ProcessContext cx, Element element, String name,
             Flow.Activity.InputBinding inputBinding) {
-        String inputStyle = getInlineActivityConfigValue(element, "inputStyle");
-        if (!inputStyle.equalsIgnoreCase("text")) {
-            throw new ParserException("Unsupported inputStyle value: " + inputStyle, element);
-        }
-        return new XMLParseActivity(element, name, inputBinding, cx.fileName());
+        XMLParseActivity.InputStyle inputStyle =
+                XMLParseActivity.InputStyle.from(getInlineActivityConfigValue(element, "inputStyle"));
+        return new XMLParseActivity(element, name, inputBinding, inputStyle, cx.fileName());
     }
 
     private static XMLRenderActivity parseXmlRenderActivity(ProcessContext cx, Element element, String name,

--- a/tibco/src/main/java/tibco/parser/XmlToTibcoModelParser.java
+++ b/tibco/src/main/java/tibco/parser/XmlToTibcoModelParser.java
@@ -348,10 +348,11 @@ public final class XmlToTibcoModelParser {
                 }
             }
         }
-        transitionGroup = transitionGroup.resolve();
         if (transitionGroup.isEmpty()) {
             return new Process6(name, nameSpaces, types, processInfo, processInterface,
                     processTemplateConfigurations, partnerLinks, variables, scope);
+        } else {
+            transitionGroup = transitionGroup.resolve();
         }
         return new Process5(name, nameSpaces, transitionGroup);
     }

--- a/tibco/src/main/java/tibco/xslt/AnalysisResult.java
+++ b/tibco/src/main/java/tibco/xslt/AnalysisResult.java
@@ -106,9 +106,12 @@ record AnalysisResult(Collection<Chunk> parameters, Collection<Chunk> paths, Col
         return new ParseResult(paths, parameters);
     }
 
-    // TODO: properly handle comments
     static ParseResult parseTag(String tagDefn, int offset) {
         assert tagDefn.startsWith("<") && tagDefn.endsWith(">");
+        if (tagDefn.startsWith("<!--") && tagDefn.endsWith("-->")) {
+            // this is a comment, skip it
+            return new ParseResult(Collections.emptyList(), Collections.emptyList());
+        }
         int index = 1;
         index = skipSpaces(tagDefn, index);
         // seek till end of tag name

--- a/tibco/src/test/resources/tibco.projects.converted/RestHelloWorld/functions.bal
+++ b/tibco/src/test/resources/tibco.projects.converted/RestHelloWorld/functions.bal
@@ -563,7 +563,7 @@ function toXML(map<anydata> data) returns error|xml {
     return xmldata:toXml(data);
 }
 
-function renderJSONAsXML(json value, string? namespace, string typeName) returns xml|error {
+function renderJSONAsXML(json value, string? namespace, string? typeName) returns xml|error {
     anydata body;
     if (value is map<json>) {
         xml acum = xml ``;
@@ -575,7 +575,8 @@ function renderJSONAsXML(json value, string? namespace, string typeName) returns
         body = value;
     }
 
-    string rep = string `<${typeName}>${body.toString()}</${typeName}>`;
+    string rep = typeName == () ? body.toString() :
+        string `<${typeName}>${body.toString()}</${typeName}>`;
     xml result = check xml:fromString(rep);
     if (namespace == ()) {
         return result;


### PR DESCRIPTION
## Purpose
$subject
Make the converter less zelous about missing parts of activity. Instead of aborting the whole conversion at least try to do parts of it
Fixes #262

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.
