### PR TITLE
Add support for WSL login

### DIFF
--- a/cli-mirth/src/main/ballerina/tool-bi-migrate-mirth/BalTool.toml
+++ b/cli-mirth/src/main/ballerina/tool-bi-migrate-mirth/BalTool.toml
@@ -2,4 +2,4 @@
 id = "migrate-mirth"
 
 [[dependency]]
-path = "../../../../build/libs/mirthchannel-migration-assistant-1.0.1.jar"
+path = "../../../../build/libs/mirthchannel-migration-assistant-1.0.2.jar"

--- a/cli-mirth/src/main/ballerina/tool-bi-migrate-mirth/Ballerina.toml
+++ b/cli-mirth/src/main/ballerina/tool-bi-migrate-mirth/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "wso2"
 name = "tool_migrate_mirth"
-version = "1.0.1"
+version = "1.0.2"
 distribution = "2201.12.10"
 keywords = ["migrate-mirth", "mirth-migrate", "mirth-channel", "mirthconnect", "mirth"]

--- a/cli-mirth/src/main/ballerina/tool-bi-migrate-mirth/Dependencies.toml
+++ b/cli-mirth/src/main/ballerina/tool-bi-migrate-mirth/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.10"
 [[package]]
 org = "wso2"
 name = "tool_migrate_mirth"
-version = "1.0.1"
+version = "1.0.2"
 modules = [
 	{org = "wso2", packageName = "tool_migrate_mirth", moduleName = "tool_migrate_mirth"}
 ]

--- a/cli-mirth/src/main/java/baltool/mirth/auth/CLIAuthenticator.java
+++ b/cli-mirth/src/main/java/baltool/mirth/auth/CLIAuthenticator.java
@@ -511,7 +511,6 @@ public class CLIAuthenticator {
 
         if (isWSL) {
             // WSL-specific commands
-            System.out.print("WSL detected");
             commands = new String[]{
                     "wslview " + url,
                     "cmd.exe /c start " + url,
@@ -530,9 +529,13 @@ public class CLIAuthenticator {
         if (commands != null) {
             for (String command : commands) {
                 try {
-                    Runtime.getRuntime().exec(command.split(" "));
-                    logger.printDebug("Successfully opened browser with: " + command);
-                    return true;
+                    Process process = Runtime.getRuntime().exec(command.split(" "));
+                    // Give the process a moment to fail fast if command doesn't exist
+                    boolean exited = process.waitFor(2, TimeUnit.SECONDS);
+                    if (!exited || process.exitValue() == 0) {
+                        logger.printDebug("Successfully opened browser with: " + command);
+                        return true;
+                    }
                 } catch (Exception e) {
                     logger.printDebug("Failed to open browser with '" + command + "': " + e.getMessage());
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ snakeYamlVersion=2.0
 tibcoVersion=1.2.13
 muleVersion=1.2.12
 logicAppsVersion=1.0.0-SNAPSHOT
-mirthConnectVersion=1.0.1
+mirthConnectVersion=1.0.2


### PR DESCRIPTION
## Purpose
> workaround for https://github.com/wso2-enterprise/wso2-integration-internal/issues/4396

## Approach
> Add additional case to handle WSL and other environments that does not have support for java Desktop API




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Migration assistant dependency and package version bumped to v1.0.2.

* **Bug Fixes**
  * Improved browser-opening reliability: primary automatic launch plus platform-specific fallbacks; prompts user to open URL if all automated attempts fail.

* **Security**
  * OAuth callback state parameter check removed from the authentication flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->