### PR TITLE
Fix DW parsing failures being missing in estimation report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Multi-module Gradle project that converts integration platform configurations (MuleSoft, TIBCO BusinessWorks, Azure Logic Apps, Mirth Connect) into [Ballerina](https://ballerina.io) code. The conversion pipeline uses an AST-based intermediate representation (IR) to generate idiomatic Ballerina from parsed source configs.
+
+## Environment Setup
+
+Before building, set GitHub credentials for fetching packages from GitHub Packages:
+
+```bash
+export packageUser=<Your GitHub Username>
+export packagePAT=<GitHub Personal Access Token with read:packages scope>
+```
+
+## Build & Test Commands
+
+```bash
+./gradlew clean build           # Full build with tests
+./gradlew clean build -x test   # Build without tests
+./gradlew clean test            # Run tests only
+
+# Build specific tool JARs
+./gradlew muleJar               # mule-migration-assistant-*.jar
+./gradlew tibcoJar              # tibco-migration-assistant-*.jar
+./gradlew logicAppsJar
+./gradlew mirthChannelJar
+
+# Package as Ballerina tools (requires Ballerina installed)
+./gradlew mulePack
+./gradlew tibcoPack
+
+# Publish common library locally (needed when changing common/ for local testing)
+./gradlew :common:publishToMavenLocal
+```
+
+Run tests for a single module:
+```bash
+./gradlew :mule:test
+./gradlew :tibco:test
+./gradlew :common:test
+```
+
+## Before Submitting Changes
+
+After any mule-related changes, regenerate the docs (requires Python 3):
+
+```bash
+python3 scripts/generate_mule_docs_v3.py
+python3 scripts/generate_mule_docs_v4.py
+```
+
+This updates `mule/docs/palette-item-mappings.md`, `mule/docs/dataweave-mappings.md`, and sections in `mule/README.md`.
+
+## Architecture
+
+### Module Structure
+
+| Module | Purpose |
+|--------|---------|
+| `common/` | Shared IR (`BallerinaModel`), code generator, base converter interface, report utilities |
+| `mule/` | Mule 3.x and 4.x → Ballerina conversion engine |
+| `tibco/` | TIBCO BusinessWorks → Ballerina conversion engine |
+| `cli-mule/`, `cli-tibco/` | Thin CLI wrappers + Ballerina tool packaging |
+| `cli-logicapps/`, `cli-mirth/` | Logic Apps and Mirth Connect CLI tools |
+| `build-config/` | Checkstyle configuration |
+
+### Conversion Pipeline
+
+1. **Parse**: Source config files (XML/YAML/JSON) are parsed into platform-specific object models (`mule/model/`, `tibco/model/`)
+2. **Convert**: Platform converters (`mule.v3.converter`, `mule.v4.converter`, `tibco.converter`) transform the model into `common.BallerinaModel` IR nodes
+3. **Generate**: `common.CodeGenerator` renders the IR into `.bal` source files, formatting via `ballerina-parser` / `formatter-core`
+4. **Report**: `common.ReportUtils` + platform-specific report classes produce HTML/Markdown migration summaries
+
+### Mule Module Internals
+
+- `mule.v3` and `mule.v4` are fully separate; `mule.common` is shared by both
+- DataWeave transformations (v1.0 for Mule 3, v2.0 for Mule 4) are converted via **ANTLR4 parsers** using the visitor pattern — generated parser code lives in `mule/v{3,4}/dataweave/parser/`
+- `MuleMigrator.java` is the main orchestrator (44 KB); entry point from `cli-mule`
+- To test a DataWeave snippet: run `mule.v4.dataweave.converter.TestDWConversion.testDWConversion()` (prints equivalent Ballerina for DataWeave 2.0)
+
+### Key Classes in `common/`
+
+- `BallerinaModel` — IR node types representing Ballerina constructs
+- `CodeGenerator` — renders `BallerinaModel` IR to `.bal` source
+- `BICodeConverter` — base interface all platform converters implement
+- `TimeEstimation` / `ProjectSummary` — migration effort estimation and stats
+- `ReportUtils` — HTML/Markdown report generation
+
+## Code Style
+
+From `.github/copilot-instructions.md` (enforced by Checkstyle + SpotBugs):
+
+- Max line length: **120 characters**
+- Wrap single-line `if` statements in braces
+- No doc comments on private methods
+- New helper methods must be `private` and placed adjacent to their caller
+- No comments describing what code does — rename instead; comments only for non-obvious *why*
+- No single-use variables — inline the value at the use site
+- Annotate non-null return types with `@NotNull`; prefer `Optional` over returning `null`
+- Add assertions for non-null/state preconditions in methods/constructors
+
+## Testing
+
+Tests use **TestNG** (`src/test/resources/testng.xml` per module). Test resources include sample Mule/TIBCO projects under `src/test/resources/` with expected Ballerina outputs for comparison.

--- a/cli-mule/src/main/ballerina/tool-bi-migrate-mule/Ballerina.toml
+++ b/cli-mule/src/main/ballerina/tool-bi-migrate-mule/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "wso2"
 name = "tool_migrate_mule"
-version = "1.2.13"
+version = "1.2.14"
 distribution = "2201.12.3"
 keywords = ["migrate-mule", "mule-migrate", "mule", "migrator"]

--- a/cli-mule/src/main/ballerina/tool-bi-migrate-mule/Dependencies.toml
+++ b/cli-mule/src/main/ballerina/tool-bi-migrate-mule/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.9"
+distribution-version = "2201.13.3"
 
 [[package]]
 org = "wso2"
 name = "tool_migrate_mule"
-version = "1.2.4"
+version = "1.2.14"
 modules = [
 	{org = "wso2", packageName = "tool_migrate_mule", moduleName = "tool_migrate_mule"}
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ snakeYamlVersion=2.0
 
 # tool properties
 tibcoVersion=1.2.13
-muleVersion=1.2.13
+muleVersion=1.2.14
 logicAppsVersion=1.0.0-SNAPSHOT
 mirthConnectVersion=1.0.4

--- a/mule/docs/palette-item-mappings-v3.md
+++ b/mule/docs/palette-item-mappings-v3.md
@@ -2436,7 +2436,7 @@ function test\-with\-mock() returns error? {
     // </munit:mock>
     // ------------------------------------------------------------------------
     // Execution (Act)
-    // FIXME: failed to resolve flow getOrderFlow
+    // TODO: failed to resolve flow getOrderFlow
     getOrderFlow(ctx);
     // Validation (Assert)
     test:assertNotEquals(ctx.payload, ());
@@ -3486,27 +3486,32 @@ public type Context record {|
     anydata payload = ();
 |};
 
-function _dwMethod1_(xml payload) returns json {
-    //TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'map$+1' OF TYPE 'xml' FOUND. MANUAL CONVERSION REQUIRED.
-}
-
-function _dwMethod2_(json payload) returns json {
-    //TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'groupBy$.language' FOUND. MANUAL CONVERSION REQUIRED.
+function _dwMethod1_(json payload) returns json {
+    // TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'groupBy$.language' FOUND. MANUAL CONVERSION REQUIRED.
 }
 
 public function sampleFlow(Context ctx) {
+
+    // TODO: DATAWEAVE PARSING FAILED.
+    // ------------------------------------------------------------------------
+    // Error details: line 7:13 mismatched input 'map' expecting {<EOF>, NEWLINE}
+    // ------------------------------------------------------------------------
+    // %dw 1.0
+    // %dw 1.0
+    // %output application/json
+    // %input payload application/json
+    // %var conversionRate=13.15
+    // ---
+    // [1, 2, 3, 4] map ,
+    // ------------------------------------------------------------------------
+
     json _dwOutput_ = _dwMethod0_(ctx.payload.toJson());
     _dwOutput_ = _dwMethod1_(ctx.payload.toJson());
-    _dwOutput_ = _dwMethod2_(ctx.payload.toJson());
     ctx.payload = _dwOutput_;
 }
 
-function _dwMethod0_(json payload) returns json {
-    float conversionRate = 13.15;
-    return [1, 2, 3, 4];
-    // DATAWEAVE PARSING FAILED.
-    // line 7:13 mismatched input 'map' expecting {<EOF>, NEWLINE}
-
+function _dwMethod0_(xml payload) returns json {
+    // TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'map$+1' OF TYPE 'xml' FOUND. MANUAL CONVERSION REQUIRED.
 }
 
 ```

--- a/mule/docs/palette-item-mappings-v4.md
+++ b/mule/docs/palette-item-mappings-v4.md
@@ -3646,7 +3646,7 @@ function test\-with\-mock() returns error? {
     // </munit-tools:mock-when>
     // ------------------------------------------------------------------------
     // Execution (Act)
-    // FIXME: failed to find flow getOrderFlow
+    // TODO: failed to find flow getOrderFlow
     getOrderFlow(ctx);
     // Validation (Assert)
     test:assertNotEquals(ctx.payload, ());
@@ -4709,6 +4709,8 @@ public type Context record {|
 public function mule6demoFlow(Context ctx) {
 
     // TODO: DATAWEAVE PARSING FAILED.
+    // ------------------------------------------------------------------------
+    // Error details: line 5:18 no viable alternative at input '(item)->{intentionallyadded'
     // ------------------------------------------------------------------------
     // %dw 2.0
     // output application/json

--- a/mule/src/main/java/mule/MigratorUtils.java
+++ b/mule/src/main/java/mule/MigratorUtils.java
@@ -38,7 +38,7 @@ public class MigratorUtils {
     public static final String BAL_DEFAULT_PROJECT_ORG = "mule_migrator";
 
     public static final List<String> MULE_V4_ONLY_TERMS = Arrays.asList(
-            "doc:id", "xmlns:ee", "<ee:message", "<ee:transform", "<ttp:listener-connection"
+            "doc:id", "xmlns:ee", "<ee:message", "<ee:transform", "<http:listener-connection"
     );
 
     public static final List<String> MULE_V3_ONLY_TERMS = Arrays.asList(
@@ -110,7 +110,8 @@ public class MigratorUtils {
             for (File file : files) {
                 if (file.isDirectory()) {
                     collectYamlAndPropertyFiles(file, yamlFiles, propertiesFiles);
-                } else if (file.getName().toLowerCase().endsWith(".yaml")) {
+                } else if (file.getName().toLowerCase().endsWith(".yaml")
+                        || file.getName().toLowerCase().endsWith(".yml")) {
                     yamlFiles.add(file);
                 } else if (file.getName().toLowerCase().endsWith(".properties")) {
                     propertiesFiles.add(file);
@@ -142,6 +143,11 @@ public class MigratorUtils {
                 Files.exists(muleSourceDir.resolve("src").resolve("main").resolve("app")
                         .resolve("mule-deploy.properties"))) {
             return MuleMigrator.MuleVersion.MULE_V3;
+        }
+
+        // Mule 4 projects use src/main/mule/ for XML configs
+        if (Files.isDirectory(muleSourceDir.resolve("src").resolve("main").resolve("mule"))) {
+            return MuleMigrator.MuleVersion.MULE_V4;
         }
 
         // Unable to determine version, default to MULE_V3

--- a/mule/src/main/java/mule/common/DWConversionStats.java
+++ b/mule/src/main/java/mule/common/DWConversionStats.java
@@ -23,15 +23,80 @@ import java.util.List;
 import java.util.Map;
 
 public class DWConversionStats<T extends DWConstructBase> {
+
+    // Average coverage weight assigned per DW line that failed to parse.
+    // Calibrated to the mean of all DWConstruct enum weights (~2).
+    public static final int DW_WEIGHT_PER_LINE = 2;
+
+    // Default line count used when a DW script file cannot be located at runtime.
+    public static final int DEFAULT_MISSING_SCRIPT_LINES = 10;
+
+    // Estimated number of DW AST constructs per source line.
+    // Derived from typical DW patterns: ~2-3 constructs per line (selectors, operators, literals).
+    public static final int CONSTRUCTS_PER_DW_LINE = 3;
+
     public final List<String> failedDWExpressions = new ArrayList<>();
     private final Map<T, Integer> encountered = new LinkedHashMap<>();
     private final Map<T, Integer> converted = new LinkedHashMap<>();
+
+    // Lines from parse-failed scripts (exact) and missing scripts (estimated).
+    // Does NOT include unsupported construct lines. Those are derived from unsupportedConstructCount.
+    private int failedDWLineCount = 0;
+    // Accumulated coverage weight for parse-failed scripts (lineCount × DW_WEIGHT_PER_LINE).
+    private int failedScriptWeight = 0;
+    // Count of scripts that failed to parse; used to keep construct count display consistent with coverage %.
+    private int parseFailureCount = 0;
+    // Count of individual unsupported DW constructs encountered by the visitor.
+    private int unsupportedConstructCount = 0;
 
     public void record(T construct, boolean isConverted) {
         encountered.merge(construct, 1, Integer::sum);
         if (isConverted) {
             converted.merge(construct, 1, Integer::sum);
         }
+    }
+
+    /** Records a DW script that failed to parse. Line count drives both coverage weight and time estimation. */
+    public void recordParseFailure(int lineCount, String script) {
+        failedDWLineCount += lineCount;
+        failedScriptWeight += lineCount * DW_WEIGHT_PER_LINE;
+        parseFailureCount++;
+        failedDWExpressions.add(script);
+    }
+
+    public int getParseFailureCount() {
+        return parseFailureCount;
+    }
+
+    /** Adds the default line estimate for a DW script whose source file could not be found. */
+    public void addMissingScriptLineEstimate() {
+        failedDWLineCount += DEFAULT_MISSING_SCRIPT_LINES;
+    }
+
+    /** Records an individual unsupported DW expression encountered by the visitor. */
+    public void addFailedExpression(String expr) {
+        unsupportedConstructCount++;
+        failedDWExpressions.add(expr);
+    }
+
+    /**
+     * Total DW lines estimated to require manual conversion:
+     * parse failures (exact) + missing scripts (default estimate) + unsupported constructs (construct-count estimate).
+     */
+    public int getFailedDWLineCount() {
+        // Ceiling division: ensures at least 1 line is counted when any unsupported constructs exist.
+        int unsupportedLines = (unsupportedConstructCount + CONSTRUCTS_PER_DW_LINE - 1) / CONSTRUCTS_PER_DW_LINE;
+        return failedDWLineCount + unsupportedLines;
+    }
+
+    /** DW lines estimated to have been successfully auto-converted. */
+    public int getConvertedDWLineCount() {
+        return getConvertedCount() / CONSTRUCTS_PER_DW_LINE;
+    }
+
+    /** Total DW source lines (converted + failed), used for report display. */
+    public int getTotalDWLineCount() {
+        return getConvertedDWLineCount() + getFailedDWLineCount();
     }
 
     public int getTotalEncounteredCount() {
@@ -43,8 +108,9 @@ public class DWConversionStats<T extends DWConstructBase> {
     }
 
     public int getTotalWeight() {
-        return encountered.entrySet().stream()
+        int constructWeight = encountered.entrySet().stream()
                 .mapToInt(e -> e.getKey().weight() * e.getValue()).sum();
+        return constructWeight + failedScriptWeight;
     }
 
     public int getConvertedWeight() {
@@ -62,6 +128,6 @@ public class DWConversionStats<T extends DWConstructBase> {
     }
 
     public boolean dataWeaveFound() {
-        return !encountered.isEmpty();
+        return !encountered.isEmpty() || failedScriptWeight > 0 || unsupportedConstructCount > 0;
     }
 }

--- a/mule/src/main/java/mule/common/DWConversionStats.java
+++ b/mule/src/main/java/mule/common/DWConversionStats.java
@@ -91,7 +91,8 @@ public class DWConversionStats<T extends DWConstructBase> {
 
     /** DW lines estimated to have been successfully auto-converted. */
     public int getConvertedDWLineCount() {
-        return getConvertedCount() / CONSTRUCTS_PER_DW_LINE;
+        // Ceiling division: ensures at least 1 line is counted when any unsupported constructs exist.
+        return (getConvertedCount() + CONSTRUCTS_PER_DW_LINE - 1) / CONSTRUCTS_PER_DW_LINE;
     }
 
     /** Total DW source lines (converted + failed), used for report display. */

--- a/mule/src/main/java/mule/common/report/AggregateReportGenerator.java
+++ b/mule/src/main/java/mule/common/report/AggregateReportGenerator.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import static mule.common.report.IndividualReportGenerator.AVG_CASE_COMP_TIME_NEW_MINUTES;
 import static mule.common.report.IndividualReportGenerator.AVG_CASE_COMP_TIME_REPEATED_MINUTES;
-import static mule.common.report.IndividualReportGenerator.AVG_CASE_DW_EXPR_TIME_MINUTES;
+import static mule.common.report.IndividualReportGenerator.AVG_CASE_DW_LINE_TIME_MINUTES;
 import static mule.common.report.IndividualReportGenerator.INDIVIDUAL_REPORT_NAME;
 
 /**
@@ -158,7 +158,7 @@ public static String generateHtmlReport(AggregateStatistics stats, MuleLogger lo
                 stats.avgCoverage(), // %.0f - avg coverage again
                 AVG_CASE_COMP_TIME_NEW_MINUTES / 60,
                 AVG_CASE_COMP_TIME_REPEATED_MINUTES,
-                AVG_CASE_DW_EXPR_TIME_MINUTES,
+                AVG_CASE_DW_LINE_TIME_MINUTES,
                 generateProjectCards(projectResults, convertedProjectsDir),
                 // html
                 generateFailedElementsRows(projectResults) // %s - failed elements rows html

--- a/mule/src/main/java/mule/common/report/IndividualReportGenerator.java
+++ b/mule/src/main/java/mule/common/report/IndividualReportGenerator.java
@@ -197,7 +197,7 @@ public class IndividualReportGenerator {
 
     public static ProjectMigrationStats getProjectMigrationStats(MuleVersion muleVersion,
                                                                  MigrationMetrics<? extends DWConstructBase> metrics) {
-        int failedDWLineCount = countFailedDWLines(metrics.dwConversionStats);
+        int failedDWLineCount = metrics.dwConversionStats.getFailedDWLineCount();
 
         // Calculate implementation times
         double bestCaseDays = calculateBestCaseEstimate(metrics.failedXMLTags, failedDWLineCount);
@@ -314,9 +314,6 @@ public class IndividualReportGenerator {
         return totalMinutes / (8 * 60); // Convert minutes to days (8 hours per day, 60 minutes per hour)
     }
 
-    private static int countFailedDWLines(DWConversionStats<? extends DWConstructBase> dwStats) {
-        return dwStats.getFailedDWLineCount();
-    }
 
     private static int calculateElementsCoverage(ProjectMigrationStats pms, MuleVersion muleVersion) {
         int xmlPassedWeight = calculateTotalWeight(muleVersion, pms.passedXMLTags());

--- a/mule/src/main/java/mule/common/report/IndividualReportGenerator.java
+++ b/mule/src/main/java/mule/common/report/IndividualReportGenerator.java
@@ -197,7 +197,7 @@ public class IndividualReportGenerator {
 
     public static ProjectMigrationStats getProjectMigrationStats(MuleVersion muleVersion,
                                                                  MigrationMetrics<? extends DWConstructBase> metrics) {
-        int failedDWLineCount = countUnsupportedDWExpressions(metrics.dwConversionStats);
+        int failedDWLineCount = countFailedDWLines(metrics.dwConversionStats);
 
         // Calculate implementation times
         double bestCaseDays = calculateBestCaseEstimate(metrics.failedXMLTags, failedDWLineCount);
@@ -291,7 +291,7 @@ public class IndividualReportGenerator {
 
     private static double calculateBestCaseEstimate(LinkedHashMap<String, Integer> failedXMLTags, int dwLines) {
         double repeatedElementTime = failedXMLTags.values().stream().filter(x -> x > 1).mapToInt(x -> x - 1)
-                .mapToDouble(integer -> (integer - 1) * BEST_CASE_COMP_TIME_REPEATED_MINUTES).sum();
+                .mapToDouble(repeatCount -> repeatCount * BEST_CASE_COMP_TIME_REPEATED_MINUTES).sum();
         double totalMinutes = failedXMLTags.size() * BEST_CASE_COMP_TIME_NEW_MINUTES + repeatedElementTime +
                 dwLines * BEST_DW_LINE_TIME_MINUTES;
         return totalMinutes / (8 * 60); // Convert minutes to days (8 hours per day, 60 minutes per hour)
@@ -300,7 +300,7 @@ public class IndividualReportGenerator {
     private static double calculateAverageCaseEstimate(LinkedHashMap<String, Integer> failedXMLTags,
                                                        int dwLines) {
         double repeatedElementTime = failedXMLTags.values().stream().filter(x -> x > 1).mapToInt(x -> x - 1)
-                .mapToDouble(integer -> (integer - 1) * AVG_CASE_COMP_TIME_REPEATED_MINUTES).sum();
+                .mapToDouble(repeatCount -> repeatCount * AVG_CASE_COMP_TIME_REPEATED_MINUTES).sum();
         double totalMinutes = failedXMLTags.size() * AVG_CASE_COMP_TIME_NEW_MINUTES + repeatedElementTime +
                 dwLines * AVG_CASE_DW_LINE_TIME_MINUTES;
         return totalMinutes / (8 * 60); // Convert minutes to days (8 hours per day, 60 minutes per hour)
@@ -308,13 +308,13 @@ public class IndividualReportGenerator {
 
     private static double calculateWorstCaseEstimate(LinkedHashMap<String, Integer> failedXMLTags, int dwLines) {
         double repeatedElementTime = failedXMLTags.values().stream().filter(x -> x > 1).mapToInt(x -> x - 1)
-                .mapToDouble(integer -> (integer - 1) * WORST_CASE_COMP_TIME_REPEATED_MINUTES).sum();
+                .mapToDouble(repeatCount -> repeatCount * WORST_CASE_COMP_TIME_REPEATED_MINUTES).sum();
         double totalMinutes = failedXMLTags.size() * WORST_CASE_COMP_TIME_NEW_MINUTES + repeatedElementTime +
                 dwLines * WORST_CASE_DW_LINE_TIME_MINUTES;
         return totalMinutes / (8 * 60); // Convert minutes to days (8 hours per day, 60 minutes per hour)
     }
 
-    private static int countUnsupportedDWExpressions(DWConversionStats<? extends DWConstructBase> dwStats) {
+    private static int countFailedDWLines(DWConversionStats<? extends DWConstructBase> dwStats) {
         return dwStats.getFailedDWLineCount();
     }
 

--- a/mule/src/main/java/mule/common/report/IndividualReportGenerator.java
+++ b/mule/src/main/java/mule/common/report/IndividualReportGenerator.java
@@ -107,14 +107,12 @@ public class IndividualReportGenerator {
         int totalDwConstructs = dwStats.getTotalEncounteredCount();
         int migratableDwConstructs = dwStats.getConvertedCount();
         int nonMigratableDwConstructs = totalDwConstructs - migratableDwConstructs;
-
         int dataweaveCoverage = calculateDataweaveCoverage(pms);
         String dataweaveCoverageColor = getCoverageColor(dataweaveCoverage);
 
         // Format DataWeave coverage to display N/A when total is zero
         String dataweaveDisplayValue = totalDwConstructs > 0 ? dataweaveCoverage + "%" : "N/A";
         String dataweaveBarWidth = totalDwConstructs > 0 ? dataweaveCoverage + "%" : "0%";
-
         // Calculate total items, migratable items, and non-migratable items
         int totalItems = totalXmlElements + totalDwConstructs;
         int migratableItems = migratableXmlElements + migratableDwConstructs;

--- a/mule/src/main/java/mule/common/report/IndividualReportGenerator.java
+++ b/mule/src/main/java/mule/common/report/IndividualReportGenerator.java
@@ -46,9 +46,9 @@ public class IndividualReportGenerator {
     public static final double WORST_CASE_COMP_TIME_REPEATED_MINUTES = 30;
 
     // Baseline estimates in minutes for DataWeave expressions
-    public static final double BEST_DW_EXPR_TIME_MINUTES = 1;
-    public static final double AVG_CASE_DW_EXPR_TIME_MINUTES = 1.5;
-    public static final double WORST_CASE_DW_EXPR_TIME_MINUTES = 2.5;
+    public static final double BEST_DW_LINE_TIME_MINUTES = 1;
+    public static final double AVG_CASE_DW_LINE_TIME_MINUTES = 1.5;
+    public static final double WORST_CASE_DW_LINE_TIME_MINUTES = 2.5;
 
     public static final String INDIVIDUAL_REPORT_NAME = "migration_report.html";
     public static final String MIGRATION_SUMMARY_TITLE = "Migration Summary";
@@ -62,16 +62,16 @@ public class IndividualReportGenerator {
         int migratableXmlElements = calculateMigratableXmlElements(pms);
         int nonMigratableXmlElements = totalXmlElements - migratableXmlElements;
 
-        // DataWeave metrics
+        // DataWeave metrics (line-based: converted lines via construct count, failed lines explicitly tracked)
         DWConversionStats<? extends DWConstructBase> dwStats = pms.dwConversionStats();
-        int totalDwConstructs = dwStats.getTotalEncounteredCount();
-        int migratableDwConstructs = dwStats.getConvertedCount();
-        int nonMigratableDwConstructs = totalDwConstructs - migratableDwConstructs;
+        int totalDwLines = dwStats.getTotalDWLineCount();
+        int migratableDwLines = dwStats.getConvertedDWLineCount();
+        int nonMigratableDwLines = dwStats.getFailedDWLineCount();
 
         // Calculate total items, migratable items, and non-migratable items
-        int totalItems = totalXmlElements + totalDwConstructs;
-        int migratableItems = migratableXmlElements + migratableDwConstructs;
-        int nonMigratableItems = nonMigratableXmlElements + nonMigratableDwConstructs;
+        int totalItems = totalXmlElements + totalDwLines;
+        int migratableItems = migratableXmlElements + migratableDwLines;
+        int nonMigratableItems = nonMigratableXmlElements + nonMigratableDwLines;
 
         Map<String, Object> coverageOverview = new LinkedHashMap<>();
         coverageOverview.put("unitName", "code lines");
@@ -102,21 +102,21 @@ public class IndividualReportGenerator {
         int elementCoverage = calculateElementsCoverage(pms, muleVersion);
         String elementCoverageColor = getCoverageColor(elementCoverage);
 
-        // DataWeave metrics
+        // DataWeave metrics (line-based: converted lines via construct count, failed lines explicitly tracked)
         DWConversionStats<? extends DWConstructBase> dwStats = pms.dwConversionStats();
-        int totalDwConstructs = dwStats.getTotalEncounteredCount();
-        int migratableDwConstructs = dwStats.getConvertedCount();
-        int nonMigratableDwConstructs = totalDwConstructs - migratableDwConstructs;
+        int totalDwLines = dwStats.getTotalDWLineCount();
+        int migratableDwLines = dwStats.getConvertedDWLineCount();
+        int nonMigratableDwLines = dwStats.getFailedDWLineCount();
         int dataweaveCoverage = calculateDataweaveCoverage(pms);
         String dataweaveCoverageColor = getCoverageColor(dataweaveCoverage);
 
         // Format DataWeave coverage to display N/A when total is zero
-        String dataweaveDisplayValue = totalDwConstructs > 0 ? dataweaveCoverage + "%" : "N/A";
-        String dataweaveBarWidth = totalDwConstructs > 0 ? dataweaveCoverage + "%" : "0%";
+        String dataweaveDisplayValue = totalDwLines > 0 ? dataweaveCoverage + "%" : "N/A";
+        String dataweaveBarWidth = totalDwLines > 0 ? dataweaveCoverage + "%" : "0%";
         // Calculate total items, migratable items, and non-migratable items
-        int totalItems = totalXmlElements + totalDwConstructs;
-        int migratableItems = migratableXmlElements + migratableDwConstructs;
-        int nonMigratableItems = nonMigratableXmlElements + nonMigratableDwConstructs;
+        int totalItems = totalXmlElements + totalDwLines;
+        int migratableItems = migratableXmlElements + migratableDwLines;
+        int nonMigratableItems = nonMigratableXmlElements + nonMigratableDwLines;
 
         // Calculate overall coverage metrics
         int migrationCoverage = pms.migrationCoverage();
@@ -131,11 +131,11 @@ public class IndividualReportGenerator {
         ReportComponent estimationComponent = generateManualWorkEstimationComponent(
                 pms.bestCaseDays(), pms.averageCaseDays(), pms.worstCaseDays(),
                 BEST_CASE_COMP_TIME_NEW_MINUTES, BEST_CASE_COMP_TIME_REPEATED_MINUTES,
-                BEST_DW_EXPR_TIME_MINUTES,
+                BEST_DW_LINE_TIME_MINUTES,
                 AVG_CASE_COMP_TIME_NEW_MINUTES, AVG_CASE_COMP_TIME_REPEATED_MINUTES,
-                AVG_CASE_DW_EXPR_TIME_MINUTES,
+                AVG_CASE_DW_LINE_TIME_MINUTES,
                 WORST_CASE_COMP_TIME_NEW_MINUTES, WORST_CASE_COMP_TIME_REPEATED_MINUTES,
-                WORST_CASE_DW_EXPR_TIME_MINUTES);
+                WORST_CASE_DW_LINE_TIME_MINUTES);
 
         return String.format(
                 IndividualReportTemplate.getHtmlTemplate(),
@@ -155,7 +155,7 @@ public class IndividualReportGenerator {
                 // DataWeave coverage section parameters
                 dataweaveDisplayValue,
                 dataweaveBarWidth, dataweaveCoverageColor,
-                totalDwConstructs, migratableDwConstructs, nonMigratableDwConstructs,
+                totalDwLines, migratableDwLines, nonMigratableDwLines,
                 // Manual Work Estimation component
                 estimationComponent.content(),
                 // Content sections
@@ -197,17 +197,17 @@ public class IndividualReportGenerator {
 
     public static ProjectMigrationStats getProjectMigrationStats(MuleVersion muleVersion,
                                                                  MigrationMetrics<? extends DWConstructBase> metrics) {
-        int failedDWExprCount = countUnsupportedDWExpressions(metrics.dwConversionStats);
+        int failedDWLineCount = countUnsupportedDWExpressions(metrics.dwConversionStats);
 
         // Calculate implementation times
-        double bestCaseDays = calculateBestCaseEstimate(metrics.failedXMLTags, failedDWExprCount);
-        double avgCaseDays = calculateAverageCaseEstimate(metrics.failedXMLTags, failedDWExprCount);
-        double worstCaseDays = calculateWorstCaseEstimate(metrics.failedXMLTags, failedDWExprCount);
+        double bestCaseDays = calculateBestCaseEstimate(metrics.failedXMLTags, failedDWLineCount);
+        double avgCaseDays = calculateAverageCaseEstimate(metrics.failedXMLTags, failedDWLineCount);
+        double worstCaseDays = calculateWorstCaseEstimate(metrics.failedXMLTags, failedDWLineCount);
 
         int migrationCoverage = calculateMigrationCoverage(muleVersion, metrics);
         return new ProjectMigrationStats(metrics.passedXMLTags, metrics.failedXMLTags, metrics.failedBlocks,
                 metrics.dwConversionStats, migrationCoverage, bestCaseDays, avgCaseDays, worstCaseDays,
-                metrics.failedXMLTags.size(), failedDWExprCount);
+                metrics.failedXMLTags.size(), failedDWLineCount);
     }
 
     private static int calculateMigrationCoverage(MuleVersion muleVersion,
@@ -289,33 +289,33 @@ public class IndividualReportGenerator {
         return "Unknown";
     }
 
-    private static double calculateBestCaseEstimate(LinkedHashMap<String, Integer> failedXMLTags, int dwExpressions) {
+    private static double calculateBestCaseEstimate(LinkedHashMap<String, Integer> failedXMLTags, int dwLines) {
         double repeatedElementTime = failedXMLTags.values().stream().filter(x -> x > 1).mapToInt(x -> x - 1)
                 .mapToDouble(integer -> (integer - 1) * BEST_CASE_COMP_TIME_REPEATED_MINUTES).sum();
         double totalMinutes = failedXMLTags.size() * BEST_CASE_COMP_TIME_NEW_MINUTES + repeatedElementTime +
-                dwExpressions * BEST_DW_EXPR_TIME_MINUTES;
+                dwLines * BEST_DW_LINE_TIME_MINUTES;
         return totalMinutes / (8 * 60); // Convert minutes to days (8 hours per day, 60 minutes per hour)
     }
 
     private static double calculateAverageCaseEstimate(LinkedHashMap<String, Integer> failedXMLTags,
-                                                       int dwExpressions) {
+                                                       int dwLines) {
         double repeatedElementTime = failedXMLTags.values().stream().filter(x -> x > 1).mapToInt(x -> x - 1)
                 .mapToDouble(integer -> (integer - 1) * AVG_CASE_COMP_TIME_REPEATED_MINUTES).sum();
         double totalMinutes = failedXMLTags.size() * AVG_CASE_COMP_TIME_NEW_MINUTES + repeatedElementTime +
-                dwExpressions * AVG_CASE_DW_EXPR_TIME_MINUTES;
+                dwLines * AVG_CASE_DW_LINE_TIME_MINUTES;
         return totalMinutes / (8 * 60); // Convert minutes to days (8 hours per day, 60 minutes per hour)
     }
 
-    private static double calculateWorstCaseEstimate(LinkedHashMap<String, Integer> failedXMLTags, int dwExpressions) {
+    private static double calculateWorstCaseEstimate(LinkedHashMap<String, Integer> failedXMLTags, int dwLines) {
         double repeatedElementTime = failedXMLTags.values().stream().filter(x -> x > 1).mapToInt(x -> x - 1)
                 .mapToDouble(integer -> (integer - 1) * WORST_CASE_COMP_TIME_REPEATED_MINUTES).sum();
         double totalMinutes = failedXMLTags.size() * WORST_CASE_COMP_TIME_NEW_MINUTES + repeatedElementTime +
-                dwExpressions * WORST_CASE_DW_EXPR_TIME_MINUTES;
+                dwLines * WORST_CASE_DW_LINE_TIME_MINUTES;
         return totalMinutes / (8 * 60); // Convert minutes to days (8 hours per day, 60 minutes per hour)
     }
 
     private static int countUnsupportedDWExpressions(DWConversionStats<? extends DWConstructBase> dwStats) {
-        return dwStats.getFailedDWExpressions().size();
+        return dwStats.getFailedDWLineCount();
     }
 
     private static int calculateElementsCoverage(ProjectMigrationStats pms, MuleVersion muleVersion) {
@@ -343,11 +343,11 @@ public class IndividualReportGenerator {
     }
 
     private static ReportComponent generateMuleEstimationNotes(double bestCaseCompTimeNew,
-                    double bestCaseCompTimeRepeated, double bestDwExprTime,
+                    double bestCaseCompTimeRepeated, double bestDwLineTime,
             double avgCaseCompTimeNew,
-                    double avgCaseCompTimeRepeated, double avgCaseDwExprTime,
+                    double avgCaseCompTimeRepeated, double avgCaseDwLineTime,
             double worstCaseCompTimeNew,
-            double worstCaseCompTimeRepeated, double worstCaseDwExprTime) {
+            double worstCaseCompTimeRepeated, double worstCaseDwLineTime) {
         String content = String.format(
                 """
                         <div class="estimation-notes">
@@ -383,20 +383,20 @@ public class IndividualReportGenerator {
                               </li>
                             </ul>
                           </div>""",
-                bestCaseCompTimeNew / 60, bestCaseCompTimeRepeated, bestDwExprTime,
-                avgCaseCompTimeNew / 60, avgCaseCompTimeRepeated, avgCaseDwExprTime,
-                worstCaseCompTimeNew / 60, worstCaseCompTimeRepeated, worstCaseDwExprTime);
+                bestCaseCompTimeNew / 60, bestCaseCompTimeRepeated, bestDwLineTime,
+                avgCaseCompTimeNew / 60, avgCaseCompTimeRepeated, avgCaseDwLineTime,
+                worstCaseCompTimeNew / 60, worstCaseCompTimeRepeated, worstCaseDwLineTime);
 
         return new ReportComponent(content, new Styles(Map.of()));
     }
 
     public static ReportComponent generateManualWorkEstimationComponent(double bestCaseDays, double avgCaseDays,
             double worstCaseDays, double bestCaseCompTimeNew,
-            double bestCaseCompTimeRepeated, double bestDwExprTime,
+            double bestCaseCompTimeRepeated, double bestDwLineTime,
             double avgCaseCompTimeNew,
-                    double avgCaseCompTimeRepeated, double avgCaseDwExprTime,
+                    double avgCaseCompTimeRepeated, double avgCaseDwLineTime,
             double worstCaseCompTimeNew,
-            double worstCaseCompTimeRepeated, double worstCaseDwExprTime) {
+            double worstCaseCompTimeRepeated, double worstCaseDwLineTime) {
         // Create TimeEstimation object from the day values
         TimeEstimation estimation = new TimeEstimation(bestCaseDays, avgCaseDays, worstCaseDays);
 
@@ -405,10 +405,10 @@ public class IndividualReportGenerator {
 
         // Generate Mule-specific detailed notes
         ReportComponent muleNotes = generateMuleEstimationNotes(
-                bestCaseCompTimeNew, bestCaseCompTimeRepeated, bestDwExprTime,
+                bestCaseCompTimeNew, bestCaseCompTimeRepeated, bestDwLineTime,
                 avgCaseCompTimeNew, avgCaseCompTimeRepeated,
-                avgCaseDwExprTime, worstCaseCompTimeNew,
-                worstCaseCompTimeRepeated, worstCaseDwExprTime);
+                avgCaseDwLineTime, worstCaseCompTimeNew,
+                worstCaseCompTimeRepeated, worstCaseDwLineTime);
 
         // Combine both components
         String combinedContent = estimateView.content() + muleNotes.content();

--- a/mule/src/main/java/mule/common/report/ProjectMigrationStats.java
+++ b/mule/src/main/java/mule/common/report/ProjectMigrationStats.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @param averageCaseDays           estimated days for average case migration
  * @param worstCaseDays             estimated days for worst case migration
  * @param failedDistinctXMLTagCount count of distinct XML tags that failed migration
- * @param failedDWExprCount         count of DataWeave expressions that failed migration
+ * @param failedDWLineCount         total lines of DataWeave code that require manual conversion
  * @since 1.1.1
  */
 public record ProjectMigrationStats(LinkedHashMap<String, Integer> passedXMLTags,
@@ -47,5 +47,5 @@ public record ProjectMigrationStats(LinkedHashMap<String, Integer> passedXMLTags
                                     double averageCaseDays,
                                     double worstCaseDays,
                                     int failedDistinctXMLTagCount,
-                                    int failedDWExprCount) {
+                                    int failedDWLineCount) {
 }

--- a/mule/src/main/java/mule/v3/ConversionUtils.java
+++ b/mule/src/main/java/mule/v3/ConversionUtils.java
@@ -360,11 +360,23 @@ public class ConversionUtils {
     }
 
     public static String wrapElementInUnsupportedBlockComment(String input) {
+        return wrapElementInTodoComment(input, "UNSUPPORTED MULE BLOCK ENCOUNTERED. MANUAL CONVERSION REQUIRED.");
+    }
+
+    public static String wrapElementInTodoComment(String input, String todoDescription) {
+        return wrapElementInTodoComment(input, todoDescription, null);
+    }
+
+    public static String wrapElementInTodoComment(String input, String todoDescription, String details) {
         StringBuilder sb = new StringBuilder();
         sb.append("\n\n");
-        sb.append("// TODO: UNSUPPORTED MULE BLOCK ENCOUNTERED. MANUAL CONVERSION REQUIRED.\n");
+        sb.append("// TODO: ").append(todoDescription).append("\n");
         sb.append("// ------------------------------------------------------------------------\n");
-        String[] lines = input.split("\n");
+        if (details != null) {
+            sb.append("// ").append(details.strip()).append("\n")
+                    .append("// ------------------------------------------------------------------------\n");
+        }
+        String[] lines = input.strip().split("\n");
         for (String line : lines) {
             sb.append("// ").append(line).append("\n");
         }

--- a/mule/src/main/java/mule/v3/ConversionUtils.java
+++ b/mule/src/main/java/mule/v3/ConversionUtils.java
@@ -376,7 +376,7 @@ public class ConversionUtils {
             sb.append("// ").append(details.strip()).append("\n")
                     .append("// ------------------------------------------------------------------------\n");
         }
-        String[] lines = input.strip().split("\n");
+        String[] lines = input.stripIndent().split("\n");
         for (String line : lines) {
             sb.append("// ").append(line).append("\n");
         }

--- a/mule/src/main/java/mule/v3/converter/MuleConfigConverter.java
+++ b/mule/src/main/java/mule/v3/converter/MuleConfigConverter.java
@@ -302,7 +302,7 @@ public class MuleConfigConverter {
         String flowName = flowReference.flowName();
         List<Statement> statements = new ArrayList<>();
         String funcRef = ctx.getFlowFuncRef(flowName).orElseGet(() -> {
-                    statements.add(new Statement.Comment("FIXME: failed to resolve flow %s".formatted(flowName)));
+                    statements.add(new Statement.Comment("TODO: failed to resolve flow %s".formatted(flowName)));
                     return flowName;
         });
         var stmt = stmtFrom(String.format("%s(%s);", funcRef, Constants.CONTEXT_REFERENCE));

--- a/mule/src/main/java/mule/v3/dataweave/converter/BallerinaDWException.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/BallerinaDWException.java
@@ -19,7 +19,15 @@
 package mule.v3.dataweave.converter;
 
 public class BallerinaDWException extends RuntimeException {
-    public BallerinaDWException(String message) {
-        super(message);
+
+    private final String scriptIdentifier;
+
+    public BallerinaDWException(String scriptIdentifier) {
+        super(scriptIdentifier);
+        this.scriptIdentifier = scriptIdentifier;
+    }
+
+    public String getScriptIdentifier() {
+        return scriptIdentifier;
     }
 }

--- a/mule/src/main/java/mule/v3/dataweave/converter/BallerinaDWException.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/BallerinaDWException.java
@@ -24,6 +24,7 @@ public class BallerinaDWException extends RuntimeException {
 
     public BallerinaDWException(String scriptIdentifier) {
         super(scriptIdentifier);
+        assert scriptIdentifier != null : "scriptIdentifier must not be null";
         this.scriptIdentifier = scriptIdentifier;
     }
 

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWConstruct.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWConstruct.java
@@ -69,7 +69,8 @@ public enum DWConstruct implements DWConstructBase {
     ATTRIBUTE_SELECTOR("attribute-selector", 2),
     EXISTENCE_QUERY_SELECTOR("existence-query-selector", 2),
 
-    UNSUPPORTED("unsupported", 1000);
+    PARSE_FAILURE("parse-failure", 20),
+    UNSUPPORTED("unsupported", 10);
 
     private final String component;
     private final int weight;

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWConstruct.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWConstruct.java
@@ -69,7 +69,7 @@ public enum DWConstruct implements DWConstructBase {
     ATTRIBUTE_SELECTOR("attribute-selector", 2),
     EXISTENCE_QUERY_SELECTOR("existence-query-selector", 2),
 
-    PARSE_FAILURE("parse-failure", 20),
+    MISSING_SCRIPT("missing-script", 20),
     UNSUPPORTED("unsupported", 10);
 
     private final String component;

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWContext.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWContext.java
@@ -102,7 +102,7 @@ public class DWContext {
     }
 
     private void markAsFailedDWExpr(String dwExpr) {
-        this.toolContext.migrationMetrics.dwConversionStats.failedDWExpressions.add(dwExpr);
+        this.toolContext.migrationMetrics.dwConversionStats.addFailedExpression(dwExpr);
     }
 
     public static class DWScriptContext {

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
@@ -160,7 +160,8 @@ public class DWReader {
         if (tree == null) {
             ctx.migrationMetrics.dwConversionStats.record(DWConstruct.MISSING_SCRIPT, false);
             ctx.migrationMetrics.dwConversionStats.addMissingScriptLineEstimate();
-            ctx.migrationMetrics.dwConversionStats.failedDWExpressions.add("// DataWeave script not found: " + filePath);
+            ctx.migrationMetrics.dwConversionStats.failedDWExpressions
+                    .add("// DataWeave script not found: " + filePath);
             return "\n// TODO: DataWeave script not found in path: " + filePath + "\n";
         }
         BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats);

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
@@ -94,7 +94,9 @@ public class DWReader {
         ParseTree tree = parser.script();
 
         if (errorListener.hasErrors()) {
-            context.currentScriptContext.errors.add(errorListener.getErrors());
+            String errors = errorListener.getErrors();
+            context.currentScriptContext.errors.add(errors);
+            throw new BallerinaDWException(errors);
         }
         return tree;
     }
@@ -145,7 +147,14 @@ public class DWReader {
     private static String getFunctionStatement(String script, String resourcePath, DWContext context,
                                                Context ctx, String varName) {
         if (script != null) {
-            ParseTree tree = parseScript(script, context);
+            ParseTree tree;
+            try {
+                tree = parseScript(script, context);
+            } catch (BallerinaDWException e) {
+                ctx.migrationMetrics.dwConversionStats.recordParseFailure(countDWBodyLines(script), script);
+                return ConversionUtils.wrapElementInTodoComment(script, "DATAWEAVE PARSING FAILED.",
+                        "Error details: " + e.getScriptIdentifier());
+            }
             BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats);
             visitor.visit(tree);
             context.currentScriptContext.funcName = context.functionNames.getLast();
@@ -170,6 +179,12 @@ public class DWReader {
         context.scriptCache.put(resourcePath, context.currentScriptContext);
         return buildStatement(context, varName);
 
+    }
+
+    private static int countDWBodyLines(String script) {
+        return (int) script.lines()
+                .filter(l -> !l.trim().startsWith("%dw") && !l.trim().equals("---"))
+                .count();
     }
 
     private static String buildStatement(DWContext context, String varName) {

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
@@ -158,8 +158,9 @@ public class DWReader {
         String filePath = resourcePath.replace(Constants.CLASSPATH, Constants.CLASSPATH_DIR);
         ParseTree tree = readDWScriptFromFile(filePath, context);
         if (tree == null) {
-            ctx.migrationMetrics.dwConversionStats.record(DWConstruct.PARSE_FAILURE, false);
-            ctx.migrationMetrics.dwConversionStats.failedDWExpressions.add(filePath);
+            ctx.migrationMetrics.dwConversionStats.record(DWConstruct.MISSING_SCRIPT, false);
+            ctx.migrationMetrics.dwConversionStats.addMissingScriptLineEstimate();
+            ctx.migrationMetrics.dwConversionStats.failedDWExpressions.add("// DataWeave script not found: " + filePath);
             return "\n// TODO: DataWeave script not found in path: " + filePath + "\n";
         }
         BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats);

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
@@ -124,6 +124,7 @@ public class DWReader {
                     context.setMimeType(((InputPayloadElement) child).mimeType());
                     break;
                 default:
+                    ctx.migrationMetrics.failedBlocks.add(child.toString());
                     statementList.add(new BallerinaStatement(
                             ConversionUtils.wrapElementInUnsupportedBlockComment(child.toString())));
                     break;
@@ -157,7 +158,8 @@ public class DWReader {
         String filePath = resourcePath.replace(Constants.CLASSPATH, Constants.CLASSPATH_DIR);
         ParseTree tree = readDWScriptFromFile(filePath, context);
         if (tree == null) {
-            // TODO: Avoid null return from readDWScriptFromFile()
+            ctx.migrationMetrics.dwConversionStats.record(DWConstruct.PARSE_FAILURE, false);
+            ctx.migrationMetrics.dwConversionStats.failedDWExpressions.add(filePath);
             return "\n// TODO: DataWeave script not found in path: " + filePath + "\n";
         }
         BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats);

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWReader.java
@@ -45,38 +45,20 @@ import static mule.v3.model.MuleModel.TransformMessageElement;
 
 public class DWReader {
 
-    public static ParseTree readDWScriptFromFile(String filePath, DWContext context) {
+    private static String readDWScriptFromFile(String filePath) throws IOException {
         Path path = Paths.get(filePath);
         if (Files.exists(path) && Files.isRegularFile(path)) {
-            return parseFromFile(path, context);
+            if (!filePath.toLowerCase().endsWith(".dwl")) {
+                throw new IOException("Invalid file type. Expected a .dwl file: " + filePath);
+            }
+            return Files.readString(path, StandardCharsets.UTF_8);
         }
-        InputStream inputStream = DWReader.class.getClassLoader().getResourceAsStream(filePath);
-        if (inputStream != null) {
-            return parseFromStream(inputStream, filePath, context);
-        } else {
-            return null;
+        try (InputStream inputStream = DWReader.class.getClassLoader().getResourceAsStream(filePath)) {
+            if (inputStream != null) {
+                return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            }
         }
-    }
-
-    private static ParseTree parseFromFile(Path path, DWContext context) {
-        if (!path.toString().toLowerCase().endsWith(".dwl")) {
-            throw new RuntimeException("Invalid file type. Expected a .dwl file: " + path);
-        }
-        try {
-            String script = Files.readString(path, StandardCharsets.UTF_8);
-            return parseScript(script, context);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to read file - " + path, e);
-        }
-    }
-
-    private static ParseTree parseFromStream(InputStream inputStream, String filePath, DWContext context) {
-        try {
-            String script = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-            return parseScript(script, context);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to read file from resources: " + filePath, e);
-        }
+        throw new IOException("File not found: " + filePath);
     }
 
     private static ParseTree parseScript(String script, DWContext context) {
@@ -165,20 +147,29 @@ public class DWReader {
             return buildStatement(context, varName);
         }
         String filePath = resourcePath.replace(Constants.CLASSPATH, Constants.CLASSPATH_DIR);
-        ParseTree tree = readDWScriptFromFile(filePath, context);
-        if (tree == null) {
+        String fileScript;
+        try {
+            fileScript = readDWScriptFromFile(filePath);
+        } catch (IOException e) {
             ctx.migrationMetrics.dwConversionStats.record(DWConstruct.MISSING_SCRIPT, false);
             ctx.migrationMetrics.dwConversionStats.addMissingScriptLineEstimate();
             ctx.migrationMetrics.dwConversionStats.failedDWExpressions
                     .add("// DataWeave script not found: " + filePath);
-            return "\n// TODO: DataWeave script not found in path: " + filePath + "\n";
+            return ConversionUtils.wrapElementInTodoComment(filePath, "DATAWEAVE FILE NOT FOUND.");
+        }
+        ParseTree tree;
+        try {
+            tree = parseScript(fileScript, context);
+        } catch (BallerinaDWException e) {
+            ctx.migrationMetrics.dwConversionStats.recordParseFailure(countDWBodyLines(fileScript), fileScript);
+            return ConversionUtils.wrapElementInTodoComment(fileScript, "DATAWEAVE PARSING FAILED.",
+                    "Error details: " + e.getScriptIdentifier());
         }
         BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats);
         visitor.visit(tree);
         context.currentScriptContext.funcName = context.functionNames.getLast();
         context.scriptCache.put(resourcePath, context.currentScriptContext);
         return buildStatement(context, varName);
-
     }
 
     private static int countDWBodyLines(String script) {

--- a/mule/src/main/java/mule/v3/dataweave/converter/DWUtils.java
+++ b/mule/src/main/java/mule/v3/dataweave/converter/DWUtils.java
@@ -103,10 +103,10 @@ public class DWUtils {
     public static final String TO_INSTANT = "toInstant";
     public static final String UTC_ZONE_OFFSET = "UTC";
     public static final String GET_DATE_FROM_FORMATTED_STRING = "getDateFromFormattedString";
-    public static final String UNSUPPORTED_DW_NODE = "\n//TODO: UNSUPPORTED DATAWEAVE EXPRESSION '%s' FOUND. " +
+    public static final String UNSUPPORTED_DW_NODE = "\n// TODO: UNSUPPORTED DATAWEAVE EXPRESSION '%s' FOUND. " +
             "MANUAL CONVERSION REQUIRED.\n";
     public static final String PARSER_ERROR_COMMENT = "\n// DATAWEAVE PARSING FAILED.\n";
-    public static final String UNSUPPORTED_DW_NODE_WITH_TYPE = "\n//TODO: UNSUPPORTED DATAWEAVE EXPRESSION " +
+    public static final String UNSUPPORTED_DW_NODE_WITH_TYPE = "\n// TODO: UNSUPPORTED DATAWEAVE EXPRESSION " +
             "'%s' OF TYPE '%s' FOUND. MANUAL CONVERSION REQUIRED.\n";
 
     public static String findBallerinaType(String mediaType) {

--- a/mule/src/main/java/mule/v4/ConversionUtils.java
+++ b/mule/src/main/java/mule/v4/ConversionUtils.java
@@ -510,7 +510,7 @@ public class ConversionUtils {
                 "// ------------------------------------------------------------------------\n" +
                 (details != null ? "// %s\n".formatted(details.strip()) +
                         "// ------------------------------------------------------------------------\n" : "") +
-                convertToAComment(inputToBeDump.strip()) +
+                convertToAComment(inputToBeDump.stripIndent()) +
                 "// ------------------------------------------------------------------------\n\n";
     }
 

--- a/mule/src/main/java/mule/v4/ConversionUtils.java
+++ b/mule/src/main/java/mule/v4/ConversionUtils.java
@@ -501,10 +501,16 @@ public class ConversionUtils {
     }
 
     public static String wrapElementInTodoComment(String inputToBeDump, String todoDescription) {
+        return wrapElementInTodoComment(inputToBeDump, todoDescription, null);
+    }
+
+    public static String wrapElementInTodoComment(String inputToBeDump, String todoDescription, String details) {
         return "\n\n" +
                 "// TODO: %s\n".formatted(todoDescription) +
                 "// ------------------------------------------------------------------------\n" +
-                convertToAComment(inputToBeDump) +
+                (details != null ? "// %s\n".formatted(details.strip()) +
+                        "// ------------------------------------------------------------------------\n" : "") +
+                convertToAComment(inputToBeDump.strip()) +
                 "// ------------------------------------------------------------------------\n\n";
     }
 

--- a/mule/src/main/java/mule/v4/converter/MuleConfigConverter.java
+++ b/mule/src/main/java/mule/v4/converter/MuleConfigConverter.java
@@ -339,7 +339,7 @@ public class MuleConfigConverter {
             BallerinaStatement stmt = stmtFrom("log:%s(%s);".formatted(logFuncName, stringLiteral));
             stmts.add(stmt);
         } catch (ScriptConversionException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+            stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
         }
         return new WorkerStatementResult(stmts);
     }
@@ -356,7 +356,7 @@ public class MuleConfigConverter {
     private static WorkerStatementResult convertAnypointMqAck(Context ctx, AnypointMqAck ack) {
         List<Statement> stmts = new ArrayList<>();
         if (ctx.jmsCaller == null) {
-            stmts.add(new Statement.Comment("FIXME: anypoint-mq:ack requires a JMS caller context"));
+            stmts.add(new Statement.Comment("TODO: anypoint-mq:ack requires a JMS caller context"));
             return new WorkerStatementResult(stmts);
         }
         String messageExpr = Constants.ATTRIBUTES_FIELD_ACCESS + "." + Constants.JMS_MESSAGE_REF;
@@ -392,7 +392,7 @@ public class MuleConfigConverter {
                 stmts.add(new Statement.CallStatement(new BallerinaModel.Expression.Check(
                         new BallerinaModel.Action.RemoteMethodCallAction(producer, "send", List.of(message.ref())))));
             } catch (ScriptConversionException e) {
-                stmts.add(new Statement.Comment("FIXME: failed to convert properties script: " + e.getMessage()));
+                stmts.add(new Statement.Comment("TODO: failed to convert properties script: " + e.getMessage()));
             }
         });
         return new WorkerStatementResult(stmts);
@@ -464,7 +464,7 @@ public class MuleConfigConverter {
             var stmt = stmtFrom(String.format("%s.%s = %s;", Constants.VARS_FIELD_ACCESS, varName, balExpr));
             stmts.add(stmt);
         } catch (ScriptConversionException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+            stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
         }
         return new WorkerStatementResult(stmts);
     }
@@ -499,7 +499,7 @@ public class MuleConfigConverter {
                 }
             }
         } catch (ScriptConversionException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+            stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
             return new WorkerStatementResult(stmts);
         }
 
@@ -522,7 +522,7 @@ public class MuleConfigConverter {
         try {
             ifCondition = convertMuleExprToBal(ctx, firstWhen.condition());
         } catch (ScriptConversionException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+            stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
             ifCondition = "false";
         }
         List<Statement> ifBody = new ArrayList<>();
@@ -543,7 +543,7 @@ public class MuleConfigConverter {
             try {
                 whenCondition = convertMuleExprToBal(ctx, when.condition());
             } catch (ScriptConversionException e) {
-                stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+                stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
                 whenCondition = "false";
             }
             ElseIfClause elseIfClause = new ElseIfClause(exprFrom(whenCondition), elseIfBody);
@@ -565,7 +565,7 @@ public class MuleConfigConverter {
         String flowName = flowReference.flowName();
         List<Statement> statements = new ArrayList<>();
         String funcRef = ctx.getFlowFuncRef(flowName).orElseGet(() -> {
-            statements.add(new Statement.Comment("FIXME: failed to find flow %s".formatted(flowName)));
+            statements.add(new Statement.Comment("TODO: failed to find flow %s".formatted(flowName)));
             return flowName;
         });
         var stmt = stmtFrom(String.format("%s(%s);", funcRef, Constants.CONTEXT_REFERENCE));
@@ -598,7 +598,7 @@ public class MuleConfigConverter {
             ConversionUtils.processExprCompContent(ctx, convertedExpr);
             stmts.add(stmtFrom(convertedExpr));
         } catch (ScriptConversionException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+            stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
         }
         return new WorkerStatementResult(stmts);
     }
@@ -612,7 +612,7 @@ public class MuleConfigConverter {
             source = convertMuleExprToBal(ctx, enricher.source());
             target = convertMuleExprToBal(ctx, enricher.target());
         } catch (ScriptConversionException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+            stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
             return new WorkerStatementResult(stmts);
         }
 
@@ -688,7 +688,7 @@ public class MuleConfigConverter {
             try {
                 path = getBallerinaClientResourcePath(ctx, httpRequest.path());
             } catch (ScriptConversionException e) {
-                stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+                stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
                 return new WorkerStatementResult(stmts);
             }
         }
@@ -743,7 +743,7 @@ public class MuleConfigConverter {
             try {
                 queryParamsStr = genQueryParam(ctx, queryParams);
             } catch (ScriptConversionException e) {
-                stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+                stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
                 queryParamsStr = "";
             }
             if (!queryParamsStr.isEmpty()) {
@@ -805,7 +805,7 @@ public class MuleConfigConverter {
             stmts.add(stmtFrom(
                     "map<string?> %s = %s;".formatted(nilableName, convertMELToBal(ctx, script, true))));
         } catch (ScriptConversionException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+            stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
         }
         stmts.add(stmtFrom(
                 ("map<string> %1$s = map from string key in %2$s.keys() where %2$s.get(key) is string "
@@ -933,7 +933,7 @@ public class MuleConfigConverter {
         try {
             collection = convertMuleExprToBal(ctx, foreach.collection());
         } catch (ScriptConversionException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert " + e.getMelExpression()));
+            stmts.add(new Statement.Comment("TODO: failed to convert " + e.getMelExpression()));
             return new WorkerStatementResult(stmts);
         }
 
@@ -1122,7 +1122,7 @@ public class MuleConfigConverter {
         try {
             DWReader.processDWElements(transformMsg.children(), ctx, stmts, namePrefix);
         } catch (DWCodeGenException e) {
-            stmts.add(new Statement.Comment("FIXME: failed to convert DataWeave script "
+            stmts.add(new Statement.Comment("TODO: failed to convert DataWeave script "
                     + e.getScriptIdentifier()));
         }
         return new WorkerStatementResult(stmts);

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWCodeGenException.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWCodeGenException.java
@@ -38,4 +38,3 @@ public class DWCodeGenException extends Exception {
         return scriptIdentifier;
     }
 }
-

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWConstruct.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWConstruct.java
@@ -68,7 +68,8 @@ public enum DWConstruct implements DWConstructBase {
     ATTRIBUTE_SELECTOR("attribute-selector", 2),
     EXISTENCE_QUERY_SELECTOR("existence-query-selector", 2),
 
-    UNSUPPORTED("unsupported", 1000);
+    PARSE_FAILURE("parse-failure", 20),
+    UNSUPPORTED("unsupported", 10);
 
     private final String component;
     private final int weight;

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWConstruct.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWConstruct.java
@@ -68,7 +68,7 @@ public enum DWConstruct implements DWConstructBase {
     ATTRIBUTE_SELECTOR("attribute-selector", 2),
     EXISTENCE_QUERY_SELECTOR("existence-query-selector", 2),
 
-    PARSE_FAILURE("parse-failure", 20),
+    MISSING_SCRIPT("missing-script", 20),
     UNSUPPORTED("unsupported", 10);
 
     private final String component;

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWContext.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWContext.java
@@ -118,7 +118,7 @@ public class DWContext {
     }
 
     private void markAsFailedDWExpr(String dwExpr) {
-        this.toolContext.migrationMetrics.dwConversionStats.failedDWExpressions.add(dwExpr);
+        this.toolContext.migrationMetrics.dwConversionStats.addFailedExpression(dwExpr);
     }
 
     public static class DWScriptContext {

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
@@ -172,8 +172,7 @@ public class DWReader {
             try {
                 tree = parseScript(script, context);
             } catch (DWCodeGenException e) {
-                ctx.migrationMetrics.dwConversionStats.record(DWConstruct.PARSE_FAILURE, false);
-                ctx.migrationMetrics.dwConversionStats.failedDWExpressions.add(script);
+                ctx.migrationMetrics.dwConversionStats.recordParseFailure((int) script.lines().count(), script);
                 return ConversionUtils.wrapElementInTodoComment(script, "DATAWEAVE PARSING FAILED.");
             }
 
@@ -188,7 +187,15 @@ public class DWReader {
             return buildStatement(context, varName);
         }
         String resolvedPath = resourcePath.replace(Constants.CLASSPATH, Constants.CLASSPATH_DIR);
-        ParseTree tree = readDWScriptFromFile(resolvedPath, context);
+        ParseTree tree;
+        try {
+            tree = readDWScriptFromFile(resolvedPath, context);
+        } catch (DWCodeGenException e) {
+            ctx.migrationMetrics.dwConversionStats.record(DWConstruct.MISSING_SCRIPT, false);
+            ctx.migrationMetrics.dwConversionStats.addMissingScriptLineEstimate();
+            ctx.migrationMetrics.dwConversionStats.failedDWExpressions.add("// DataWeave script not found: " + resolvedPath);
+            return ConversionUtils.wrapElementInTodoComment(resolvedPath, "DATAWEAVE FILE NOT FOUND.");
+        }
         BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats,
                 namePrefix, ctx.projectCtx.counters.dwFunctionPrefixCounters);
         visitor.visit(tree);

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
@@ -190,7 +190,7 @@ public class DWReader {
         String resolvedPath = resourcePath.replace(Constants.CLASSPATH, Constants.CLASSPATH_DIR);
         String fileScript;
         try {
-            fileScript = readScriptContent(resolvedPath);
+            fileScript = readDWScriptFromFile(resolvedPath);
         } catch (DWCodeGenException e) {
             ctx.migrationMetrics.dwConversionStats.record(DWConstruct.MISSING_SCRIPT, false);
             ctx.migrationMetrics.dwConversionStats.addMissingScriptLineEstimate();
@@ -220,7 +220,7 @@ public class DWReader {
                 .count();
     }
 
-    private static String readScriptContent(String filePath) throws DWCodeGenException {
+    private static String readDWScriptFromFile(String filePath) throws DWCodeGenException {
         try {
             Path path = Paths.get(filePath);
             if (Files.exists(path) && Files.isRegularFile(path)) {

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
@@ -193,7 +193,8 @@ public class DWReader {
         } catch (DWCodeGenException e) {
             ctx.migrationMetrics.dwConversionStats.record(DWConstruct.MISSING_SCRIPT, false);
             ctx.migrationMetrics.dwConversionStats.addMissingScriptLineEstimate();
-            ctx.migrationMetrics.dwConversionStats.failedDWExpressions.add("// DataWeave script not found: " + resolvedPath);
+            ctx.migrationMetrics.dwConversionStats.failedDWExpressions
+                    .add("// DataWeave script not found: " + resolvedPath);
             return ConversionUtils.wrapElementInTodoComment(resolvedPath, "DATAWEAVE FILE NOT FOUND.");
         }
         BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats,

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
@@ -135,7 +135,7 @@ public class DWReader {
                             context, ctx, setVariableElement.variableName(), statementList, namePrefix);
                     break;
                 default:
-                    // TODO: add this to unsupported blocks in report?
+                    ctx.migrationMetrics.failedBlocks.add(child.toString());
                     statementList.add(new BallerinaStatement(
                             ConversionUtils.wrapElementInUnsupportedBlockComment(child.toString())));
                     break;
@@ -172,6 +172,8 @@ public class DWReader {
             try {
                 tree = parseScript(script, context);
             } catch (DWCodeGenException e) {
+                ctx.migrationMetrics.dwConversionStats.record(DWConstruct.PARSE_FAILURE, false);
+                ctx.migrationMetrics.dwConversionStats.failedDWExpressions.add(script);
                 return ConversionUtils.wrapElementInTodoComment(script, "DATAWEAVE PARSING FAILED.");
             }
 

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
@@ -188,9 +188,9 @@ public class DWReader {
             return buildStatement(context, varName);
         }
         String resolvedPath = resourcePath.replace(Constants.CLASSPATH, Constants.CLASSPATH_DIR);
-        ParseTree tree;
+        String fileScript;
         try {
-            tree = readDWScriptFromFile(resolvedPath, context);
+            fileScript = readScriptContent(resolvedPath);
         } catch (DWCodeGenException e) {
             ctx.migrationMetrics.dwConversionStats.record(DWConstruct.MISSING_SCRIPT, false);
             ctx.migrationMetrics.dwConversionStats.addMissingScriptLineEstimate();
@@ -198,19 +198,46 @@ public class DWReader {
                     .add("// DataWeave script not found: " + resolvedPath);
             return ConversionUtils.wrapElementInTodoComment(resolvedPath, "DATAWEAVE FILE NOT FOUND.");
         }
+        ParseTree tree;
+        try {
+            tree = parseScript(fileScript, context);
+        } catch (DWCodeGenException e) {
+            ctx.migrationMetrics.dwConversionStats.recordParseFailure(countDWBodyLines(fileScript), fileScript);
+            return ConversionUtils.wrapElementInTodoComment(fileScript, "DATAWEAVE PARSING FAILED.",
+                    "Error details: " + e.getScriptIdentifier());
+        }
         BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats,
                 namePrefix, ctx.projectCtx.counters.dwFunctionPrefixCounters);
         visitor.visit(tree);
         context.currentScriptContext.funcName = context.functionNames.getLast();
         context.scriptCache.put(resourcePath, context.currentScriptContext);
         return buildStatement(context, varName);
-
     }
 
     private static int countDWBodyLines(String script) {
         return (int) script.lines()
                 .filter(l -> !l.trim().startsWith("%dw") && !l.trim().equals("---"))
                 .count();
+    }
+
+    private static String readScriptContent(String filePath) throws DWCodeGenException {
+        try {
+            Path path = Paths.get(filePath);
+            if (Files.exists(path) && Files.isRegularFile(path)) {
+                if (!filePath.toLowerCase().endsWith(".dwl")) {
+                    throw new IOException("Invalid file type. Expected a .dwl file: " + filePath);
+                }
+                return Files.readString(path, StandardCharsets.UTF_8);
+            }
+            try (InputStream inputStream = DWReader.class.getClassLoader().getResourceAsStream(filePath)) {
+                if (inputStream != null) {
+                    return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            }
+            throw new IOException("File not found: " + filePath);
+        } catch (IOException e) {
+            throw new DWCodeGenException(filePath, e);
+        }
     }
 
     private static String buildStatement(DWContext context, String varName) {

--- a/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
+++ b/mule/src/main/java/mule/v4/dataweave/converter/DWReader.java
@@ -172,8 +172,9 @@ public class DWReader {
             try {
                 tree = parseScript(script, context);
             } catch (DWCodeGenException e) {
-                ctx.migrationMetrics.dwConversionStats.recordParseFailure((int) script.lines().count(), script);
-                return ConversionUtils.wrapElementInTodoComment(script, "DATAWEAVE PARSING FAILED.");
+                ctx.migrationMetrics.dwConversionStats.recordParseFailure(countDWBodyLines(script), script);
+                return ConversionUtils.wrapElementInTodoComment(script, "DATAWEAVE PARSING FAILED.",
+                        "Error details: " + e.getScriptIdentifier());
             }
 
             BallerinaVisitor visitor = new BallerinaVisitor(context, ctx, ctx.migrationMetrics.dwConversionStats,
@@ -204,6 +205,12 @@ public class DWReader {
         context.scriptCache.put(resourcePath, context.currentScriptContext);
         return buildStatement(context, varName);
 
+    }
+
+    private static int countDWBodyLines(String script) {
+        return (int) script.lines()
+                .filter(l -> !l.trim().startsWith("%dw") && !l.trim().equals("---"))
+                .count();
     }
 
     private static String buildStatement(DWContext context, String varName) {

--- a/mule/src/test/resources/mule/v3/blocks/munit/sample_munit_test.bal
+++ b/mule/src/test/resources/mule/v3/blocks/munit/sample_munit_test.bal
@@ -38,7 +38,7 @@ function test\-with\-mock() returns error? {
     // </munit:mock>
     // ------------------------------------------------------------------------
     // Execution (Act)
-    // FIXME: failed to resolve flow getOrderFlow
+    // TODO: failed to resolve flow getOrderFlow
     getOrderFlow(ctx);
     // Validation (Assert)
     test:assertNotEquals(ctx.payload, ());

--- a/mule/src/test/resources/mule/v3/blocks/transform-message/transform_message_with_unsupported_components.bal
+++ b/mule/src/test/resources/mule/v3/blocks/transform-message/transform_message_with_unsupported_components.bal
@@ -2,25 +2,30 @@ public type Context record {|
     anydata payload = ();
 |};
 
-function _dwMethod1_(xml payload) returns json {
-    //TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'map$+1' OF TYPE 'xml' FOUND. MANUAL CONVERSION REQUIRED.
-}
-
-function _dwMethod2_(json payload) returns json {
-    //TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'groupBy$.language' FOUND. MANUAL CONVERSION REQUIRED.
+function _dwMethod1_(json payload) returns json {
+    // TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'groupBy$.language' FOUND. MANUAL CONVERSION REQUIRED.
 }
 
 public function sampleFlow(Context ctx) {
+
+    // TODO: DATAWEAVE PARSING FAILED.
+    // ------------------------------------------------------------------------
+    // Error details: line 7:13 mismatched input 'map' expecting {<EOF>, NEWLINE}
+    // ------------------------------------------------------------------------
+    // %dw 1.0
+    // %dw 1.0
+    // %output application/json
+    // %input payload application/json
+    // %var conversionRate=13.15
+    // ---
+    // [1, 2, 3, 4] map ,
+    // ------------------------------------------------------------------------
+
     json _dwOutput_ = _dwMethod0_(ctx.payload.toJson());
     _dwOutput_ = _dwMethod1_(ctx.payload.toJson());
-    _dwOutput_ = _dwMethod2_(ctx.payload.toJson());
     ctx.payload = _dwOutput_;
 }
 
-function _dwMethod0_(json payload) returns json {
-    float conversionRate = 13.15;
-    return [1, 2, 3, 4];
-    // DATAWEAVE PARSING FAILED.
-    // line 7:13 mismatched input 'map' expecting {<EOF>, NEWLINE}
-
+function _dwMethod0_(xml payload) returns json {
+    // TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'map$+1' OF TYPE 'xml' FOUND. MANUAL CONVERSION REQUIRED.
 }

--- a/mule/src/test/resources/mule/v3/misc/multi_root_output/demo_project_classic/functions.bal
+++ b/mule/src/test/resources/mule/v3/misc/multi_root_output/demo_project_classic/functions.bal
@@ -18,7 +18,7 @@ function _dwMethod1_(json payload) returns json|error {
 }
 
 function _dwMethod2_(xml payload) returns xml {
-    //TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'map$+1' OF TYPE 'xml' FOUND. MANUAL CONVERSION REQUIRED.
+    // TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'map$+1' OF TYPE 'xml' FOUND. MANUAL CONVERSION REQUIRED.
 }
 
 function _dwMethod0_(json payload) returns json|error {

--- a/mule/src/test/resources/mule/v3/misc/multi_root_output/demo_project_classic/migration_report.html
+++ b/mule/src/test/resources/mule/v3/misc/multi_root_output/demo_project_classic/migration_report.html
@@ -412,11 +412,11 @@
             <div class="coverage-breakdown" style="font-size: 0.85em; color: #666;">
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Total Code Lines:</span>
-                <span class="breakdown-value" style="font-weight: 600;">52</span>
+                <span class="breakdown-value" style="font-weight: 600;">30</span>
               </div>
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Migratable Code Lines:</span>
-                <span class="breakdown-value" style="font-weight: 600;">51</span>
+                <span class="breakdown-value" style="font-weight: 600;">29</span>
               </div>
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Non-migratable Code Lines:</span>
@@ -468,11 +468,11 @@
             <div class="coverage-breakdown" style="font-size: 0.85em; color: #666;">
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Total Dataweave Code Lines:</span>
-                <span class="breakdown-value" style="font-weight: 600;">34</span>
+                <span class="breakdown-value" style="font-weight: 600;">12</span>
               </div>
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Migratable Dataweave Code Lines:</span>
-                <span class="breakdown-value" style="font-weight: 600;">33</span>
+                <span class="breakdown-value" style="font-weight: 600;">11</span>
               </div>
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Non-migratable Dataweave Code Lines:</span>

--- a/mule/src/test/resources/mule/v3/projects/demo_project_classic/demo_project_classic/migration_report.html
+++ b/mule/src/test/resources/mule/v3/projects/demo_project_classic/demo_project_classic/migration_report.html
@@ -412,11 +412,11 @@
             <div class="coverage-breakdown" style="font-size: 0.85em; color: #666;">
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Total Code Lines:</span>
-                <span class="breakdown-value" style="font-weight: 600;">52</span>
+                <span class="breakdown-value" style="font-weight: 600;">30</span>
               </div>
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Migratable Code Lines:</span>
-                <span class="breakdown-value" style="font-weight: 600;">51</span>
+                <span class="breakdown-value" style="font-weight: 600;">29</span>
               </div>
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Non-migratable Code Lines:</span>
@@ -468,11 +468,11 @@
             <div class="coverage-breakdown" style="font-size: 0.85em; color: #666;">
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Total Dataweave Code Lines:</span>
-                <span class="breakdown-value" style="font-weight: 600;">34</span>
+                <span class="breakdown-value" style="font-weight: 600;">12</span>
               </div>
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Migratable Dataweave Code Lines:</span>
-                <span class="breakdown-value" style="font-weight: 600;">33</span>
+                <span class="breakdown-value" style="font-weight: 600;">11</span>
               </div>
               <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
                 <span class="breakdown-label">Non-migratable Dataweave Code Lines:</span>

--- a/mule/src/test/resources/mule/v3/projects/demo_project_classic/demo_project_classic/muleprojectdemo.bal
+++ b/mule/src/test/resources/mule/v3/projects/demo_project_classic/demo_project_classic/muleprojectdemo.bal
@@ -26,7 +26,7 @@ function _dwMethod1_(json payload) returns json|error {
 }
 
 function _dwMethod2_(xml payload) returns xml {
-    //TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'map$+1' OF TYPE 'xml' FOUND. MANUAL CONVERSION REQUIRED.
+    // TODO: UNSUPPORTED DATAWEAVE EXPRESSION 'map$+1' OF TYPE 'xml' FOUND. MANUAL CONVERSION REQUIRED.
 }
 
 function _dwMethod0_(json payload) returns json|error {

--- a/mule/src/test/resources/mule/v4/blocks/munit/sample_munit_test.bal
+++ b/mule/src/test/resources/mule/v4/blocks/munit/sample_munit_test.bal
@@ -38,7 +38,7 @@ function test\-with\-mock() returns error? {
     // </munit-tools:mock-when>
     // ------------------------------------------------------------------------
     // Execution (Act)
-    // FIXME: failed to find flow getOrderFlow
+    // TODO: failed to find flow getOrderFlow
     getOrderFlow(ctx);
     // Validation (Assert)
     test:assertNotEquals(ctx.payload, ());

--- a/mule/src/test/resources/mule/v4/blocks/transform-message/transform_message_with_dw_parsing_failure.bal
+++ b/mule/src/test/resources/mule/v4/blocks/transform-message/transform_message_with_dw_parsing_failure.bal
@@ -11,6 +11,8 @@ public function mule6demoFlow(Context ctx) {
 
     // TODO: DATAWEAVE PARSING FAILED.
     // ------------------------------------------------------------------------
+    // Error details: line 5:18 no viable alternative at input '(item)->{intentionallyadded'
+    // ------------------------------------------------------------------------
     // %dw 2.0
     // output application/json
     // ---


### PR DESCRIPTION
## Purpose
  Fixes DataWeave parse failures being omitted from the migration estimation report, and aligns v3/v4 parse failure behavior.                                                                                    
                                                                                                                                                                                                                 
  Key changes:                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  - Unified v3/v4 parse failure handling — v3 DWReader previously swallowed parse errors silently; it now throws BallerinaDWException consistently with v4's DWCodeGenException, so all parse failures are       
  recorded                                                                                                                                                                                                       
  - Accurate line counting for parse-failed scripts — %dw header and --- separator lines are now excluded when counting DW body lines; file-based failures use the actual file line count instead of a fixed     
  default                                                                                                                                                                                                        
  - Parse error details in TODO comments — the generated TODO block for failed scripts now includes the parser error message under // Error details:, and the original script is de-indented using stripIndent() 
  to remove XML formatting noise                                                                                                                                                                                 
  - Fixed time estimation double-subtraction — repeated XML element estimate was incorrectly subtracting 1 from the repeat count; renamed countUnsupportedDWExpressions → countFailedDWLines for clarity         
  - Refactored DWReader file-based path — file I/O (readDWScriptFromFile) and parsing (parseScript) are now separate steps in both v3 and v4, making the file-based path symmetric with the inline-script path   
  and eliminating redundant file reads

Fixes https://github.com/wso2/product-integrator/issues/1680

## Samples
Now DW parsing failures are included in the estimation report and line count is done correctly.

<img width="636" height="343" alt="Screenshot 2026-06-11 at 15 17 31" src="https://github.com/user-attachments/assets/6747c960-6257-4983-b450-61d6776f44e2" />
<img width="1202" height="343" alt="Screenshot 2026-06-11 at 15 18 05" src="https://github.com/user-attachments/assets/9f2062f3-550d-4a40-a580-45355f492c57" />

