### PR TITLE
Support `property` mediator migration

### DIFF
--- a/cli-synapse/src/test/java/synapse/converter/PropertyScopeTest.java
+++ b/cli-synapse/src/test/java/synapse/converter/PropertyScopeTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package synapse.converter;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.testng.Assert.assertThrows;
+
+/**
+ * Verifies that property scopes with no supported Ballerina translation are rejected rather than
+ * silently mis-converted: a {@code remove} action outside the default/synapse scope (transport, axis2),
+ * and any scope other than transport, axis2, default or synapse.
+ */
+public class PropertyScopeTest {
+
+    private static final Path UNSUPPORTED = Path.of("src", "test", "resources", "unsupported-property");
+
+    @Test(dataProvider = "unsupportedCaseProvider")
+    public void unsupportedPropertyScopeIsRejected(String project) {
+        assertThrows(UnsupportedOperationException.class, () -> convert(project));
+    }
+
+    private static void convert(String project) throws IOException {
+        Path output = Files.createTempDirectory("synapse-unsupported-property-test");
+        try {
+            SynapseConverter.migrateSynapse(UNSUPPORTED.resolve(project).toString(), output.toString(),
+                    false, false, false, false, Optional.of("testOrg"), Optional.of("pkg"));
+        } finally {
+            TestUtils.deleteDirectory(output);
+        }
+    }
+
+    @DataProvider
+    public Object[][] unsupportedCaseProvider() {
+        return new Object[][]{
+                {"transport-remove"},
+                {"axis2-remove"},
+                {"unknown-scope"},
+        };
+    }
+}

--- a/cli-synapse/src/test/java/synapse/converter/SynapseImportsTest.java
+++ b/cli-synapse/src/test/java/synapse/converter/SynapseImportsTest.java
@@ -84,8 +84,8 @@ public class SynapseImportsTest {
             // 'plain' (no http) is flushed before 'withPayload' (needs http), yet the import stays on top.
             assertTrue(functions.stripLeading().startsWith(HTTP_IMPORT),
                     "http import must be prepended to the top of functions.bal");
-            assertTrue(functions.contains("function plain()"));
-            assertTrue(functions.contains("function withPayload(http:Response response)"));
+            assertTrue(functions.contains("function plain(Context ctx)"));
+            assertTrue(functions.contains("function withPayload(Context ctx, http:Response response)"));
         } finally {
             TestUtils.deleteDirectory(output);
         }

--- a/cli-synapse/src/test/java/synapse/converter/TestUtils.java
+++ b/cli-synapse/src/test/java/synapse/converter/TestUtils.java
@@ -33,11 +33,6 @@ import java.util.stream.Stream;
  */
 public final class TestUtils {
 
-    /**
-     * When {@code -Dsynapse.test.updateExpected=true} is passed, {@link #compareDirectories} rewrites
-     * the expected packages from the generated output instead of asserting, regenerating the golden
-     * files after an intentional converter change. Off by default, so a normal run fails on any drift.
-     */
     private static final boolean UPDATE_EXPECTED = false;
 
     private TestUtils() {
@@ -65,11 +60,6 @@ public final class TestUtils {
         }
     }
 
-    /**
-     * Overwrite {@code expected} so it mirrors the generated {@code actual} package: every generated
-     * file is copied over, and any expected file no longer generated is deleted. Used only under
-     * {@link #UPDATE_EXPECTED} to refresh the golden output after an intentional change.
-     */
     private static void regenerateExpected(Path actual, Path expected) throws IOException {
         try (Stream<Path> actualFiles = Files.walk(actual)) {
             for (Path relativePath : actualFiles.filter(Files::isRegularFile).map(actual::relativize).toList()) {
@@ -114,11 +104,6 @@ public final class TestUtils {
         }
     }
 
-    /**
-     * Describe how two files differ, normalizing line endings, or {@link Optional#empty()} when they
-     * are identical. On mismatch the message pinpoints the first differing line so a failure is easy
-     * to act on.
-     */
     private static Optional<String> describeDifference(Path actual, Path expected) throws IOException {
         String actualContent = Files.readString(actual).replace("\r\n", "\n");
         String expectedContent = Files.readString(expected).replace("\r\n", "\n");

--- a/cli-synapse/src/test/java/synapse/converter/TestUtils.java
+++ b/cli-synapse/src/test/java/synapse/converter/TestUtils.java
@@ -22,8 +22,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -31,66 +33,109 @@ import java.util.stream.Stream;
  */
 public final class TestUtils {
 
+    /**
+     * When {@code -Dsynapse.test.updateExpected=true} is passed, {@link #compareDirectories} rewrites
+     * the expected packages from the generated output instead of asserting, regenerating the golden
+     * files after an intentional converter change. Off by default, so a normal run fails on any drift.
+     */
+    private static final boolean UPDATE_EXPECTED = false;
+
     private TestUtils() {
     }
 
     /**
-     * Compare every regular file under {@code expected} with the file at the same relative path
-     * under {@code actual}. When the contents differ, the expected (Ballerina) file is overwritten
-     * with the generated output. Newly generated files with no counterpart under {@code expected}
-     * are created as well.
+     * Assert that the generated package at {@code actual} matches the expected package at
+     * {@code expected}, file for file. Every discrepancy — a differing file, an expected file that
+     * was not generated, or a generated file with no expected counterpart — is collected and reported
+     * together in a single {@link AssertionError}. Expected files are never modified unless
+     * {@link #UPDATE_EXPECTED} is set, in which case they are regenerated to match the output.
      */
     public static void compareDirectories(Path actual, Path expected) throws IOException {
-        try (Stream<Path> expectedFiles = Files.walk(expected)) {
-            List<Path> expectedPaths = expectedFiles
-                    .filter(Files::isRegularFile)
-                    .map(expected::relativize)
-                    .toList();
-
-            for (Path relativePath : expectedPaths) {
-                Path actualFile = actual.resolve(relativePath);
-                if (!Files.exists(actualFile)) {
-                    throw new AssertionError("Expected file missing in actual output: " + relativePath);
-                }
-                compareFiles(actualFile, expected.resolve(relativePath));
-            }
+        assert actual != null && expected != null : "actual and expected paths must not be null";
+        if (UPDATE_EXPECTED) {
+            regenerateExpected(actual, expected);
+            return;
         }
-        copyNewFiles(actual, expected);
+        List<String> mismatches = new ArrayList<>();
+        collectMissingAndDiffering(actual, expected, mismatches);
+        collectUnexpected(actual, expected, mismatches);
+        if (!mismatches.isEmpty()) {
+            throw new AssertionError("Generated package does not match expected at " + expected + ":\n"
+                    + String.join("\n", mismatches));
+        }
     }
 
     /**
-     * Compare the textual contents of two files, normalizing line endings. On mismatch the expected
-     * file is overwritten with the actual (generated) contents.
+     * Overwrite {@code expected} so it mirrors the generated {@code actual} package: every generated
+     * file is copied over, and any expected file no longer generated is deleted. Used only under
+     * {@link #UPDATE_EXPECTED} to refresh the golden output after an intentional change.
      */
-    public static void compareFiles(Path actual, Path expected) throws IOException {
+    private static void regenerateExpected(Path actual, Path expected) throws IOException {
+        try (Stream<Path> actualFiles = Files.walk(actual)) {
+            for (Path relativePath : actualFiles.filter(Files::isRegularFile).map(actual::relativize).toList()) {
+                Path expectedFile = expected.resolve(relativePath);
+                Files.createDirectories(expectedFile.getParent());
+                Files.copy(actual.resolve(relativePath), expectedFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+        try (Stream<Path> expectedFiles = Files.walk(expected)) {
+            for (Path relativePath : expectedFiles.filter(Files::isRegularFile).map(expected::relativize).toList()) {
+                if (!Files.exists(actual.resolve(relativePath))) {
+                    Files.delete(expected.resolve(relativePath));
+                }
+            }
+        }
+    }
+
+    private static void collectMissingAndDiffering(Path actual, Path expected, List<String> mismatches)
+            throws IOException {
+        try (Stream<Path> expectedFiles = Files.walk(expected)) {
+            for (Path relativePath : expectedFiles.filter(Files::isRegularFile).map(expected::relativize).toList()) {
+                Path actualFile = actual.resolve(relativePath);
+                if (!Files.exists(actualFile)) {
+                    mismatches.add("  missing: " + relativePath + " was not generated");
+                    continue;
+                }
+                Optional<String> difference = describeDifference(actualFile, expected.resolve(relativePath));
+                if (difference.isPresent()) {
+                    mismatches.add("  differs: " + relativePath + " -> " + difference.get());
+                }
+            }
+        }
+    }
+
+    private static void collectUnexpected(Path actual, Path expected, List<String> mismatches) throws IOException {
+        try (Stream<Path> actualFiles = Files.walk(actual)) {
+            for (Path relativePath : actualFiles.filter(Files::isRegularFile).map(actual::relativize).toList()) {
+                if (!Files.exists(expected.resolve(relativePath))) {
+                    mismatches.add("  unexpected: " + relativePath + " was generated but is not expected");
+                }
+            }
+        }
+    }
+
+    /**
+     * Describe how two files differ, normalizing line endings, or {@link Optional#empty()} when they
+     * are identical. On mismatch the message pinpoints the first differing line so a failure is easy
+     * to act on.
+     */
+    private static Optional<String> describeDifference(Path actual, Path expected) throws IOException {
         String actualContent = Files.readString(actual).replace("\r\n", "\n");
         String expectedContent = Files.readString(expected).replace("\r\n", "\n");
         if (actualContent.equals(expectedContent)) {
-            return;
+            return Optional.empty();
         }
-        Files.createDirectories(expected.getParent());
-        Files.copy(actual, expected, StandardCopyOption.REPLACE_EXISTING);
-    }
-
-    /**
-     * Copy every regular file under {@code actual} that has no counterpart at the same relative path
-     * under {@code expected} into {@code expected}, capturing newly generated files.
-     */
-    public static void copyNewFiles(Path actual, Path expected) throws IOException {
-        try (Stream<Path> actualFiles = Files.walk(actual)) {
-            List<Path> relativePaths = actualFiles
-                    .filter(Files::isRegularFile)
-                    .map(actual::relativize)
-                    .toList();
-
-            for (Path relativePath : relativePaths) {
-                Path expectedFile = expected.resolve(relativePath);
-                if (!Files.exists(expectedFile)) {
-                    Files.createDirectories(expectedFile.getParent());
-                    Files.copy(actual.resolve(relativePath), expectedFile, StandardCopyOption.REPLACE_EXISTING);
-                }
+        List<String> actualLines = actualContent.lines().toList();
+        List<String> expectedLines = expectedContent.lines().toList();
+        for (int line = 0; line < Math.max(actualLines.size(), expectedLines.size()); line++) {
+            String expectedLine = line < expectedLines.size() ? expectedLines.get(line) : "<no such line>";
+            String actualLine = line < actualLines.size() ? actualLines.get(line) : "<no such line>";
+            if (!expectedLine.equals(actualLine)) {
+                return Optional.of("first differs at line " + (line + 1)
+                        + "\n      expected: " + expectedLine + "\n      actual:   " + actualLine);
             }
         }
+        return Optional.of("content differs only in trailing whitespace or final newline");
     }
 
     /**

--- a/cli-synapse/src/test/resources/ballerina/property1/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property1/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property1"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property1/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/property1/functions.bal
@@ -1,0 +1,5 @@
+function seq(Context ctx) {
+    ctx.greeting = "Hello";
+    ctx.count = 5;
+    ctx.enabled = true;
+}

--- a/cli-synapse/src/test/resources/ballerina/property1/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property1/main.bal
@@ -1,0 +1,3 @@
+import ballerina/http;
+
+public listener http:Listener httpListener = new (8080);

--- a/cli-synapse/src/test/resources/ballerina/property1/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property1/types.bal
@@ -1,0 +1,5 @@
+public type Context record {|
+    string greeting?;
+    int count?;
+    boolean enabled?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/property2/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property2/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property2"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property2/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/property2/functions.bal
@@ -1,0 +1,10 @@
+function bar(Context ctx) {
+    ctx.barProp1 = "bar-one";
+    ctx.barProp2 = 10;
+}
+
+function foo(Context ctx) {
+    ctx.before = "before";
+    bar(ctx);
+    ctx.after = "after";
+}

--- a/cli-synapse/src/test/resources/ballerina/property2/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property2/main.bal
@@ -1,0 +1,3 @@
+import ballerina/http;
+
+public listener http:Listener httpListener = new (8080);

--- a/cli-synapse/src/test/resources/ballerina/property2/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property2/types.bal
@@ -1,0 +1,6 @@
+public type Context record {|
+    string barProp1?;
+    int barProp2?;
+    string before?;
+    string after?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/property3/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property3/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property3"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property3/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property3/main.bal
@@ -1,0 +1,23 @@
+import ballerina/http;
+
+public listener http:Listener httpListener = new (8080);
+
+service /orders on httpListener {
+    resource function get list() returns http:Response {
+        http:Response response = new;
+        Context ctx = {};
+        ctx.prop1 = "list";
+        ctx.r1only = 1;
+        response.setPayload({"resource": "list"});
+        return response;
+    }
+
+    resource function post create() returns http:Response {
+        http:Response response = new;
+        Context ctx = {};
+        ctx.prop1 = "create";
+        ctx.r2only = true;
+        response.setPayload({"resource": "create"});
+        return response;
+    }
+}

--- a/cli-synapse/src/test/resources/ballerina/property3/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property3/types.bal
@@ -1,0 +1,5 @@
+public type Context record {|
+    string prop1?;
+    int r1only?;
+    boolean r2only?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/property4/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property4/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property4"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property4/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property4/main.bal
@@ -1,0 +1,23 @@
+import ballerina/http;
+
+public listener http:Listener httpListener = new (8080);
+
+service /orders on httpListener {
+    resource function get list() returns http:Response {
+        http:Response response = new;
+        Context ctx = {};
+        ctx.prop1 = "list";
+        ctx.r1only = 1;
+        response.setPayload({"resource": "list"});
+        return response;
+    }
+
+    resource function post create() returns http:Response {
+        http:Response response = new;
+        Context ctx = {};
+        ctx.prop1 = 55;
+        ctx.r2only = true;
+        response.setPayload({"resource": "create"});
+        return response;
+    }
+}

--- a/cli-synapse/src/test/resources/ballerina/property4/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property4/types.bal
@@ -1,0 +1,5 @@
+public type Context record {|
+    string|int prop1?;
+    int r1only?;
+    boolean r2only?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/property5/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property5/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property5"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property5/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/property5/functions.bal
@@ -1,0 +1,10 @@
+function bar(Context ctx) {
+    ctx.barProp1 = "bar-one";
+    ctx.barProp2 = 10;
+}
+
+function foo(Context ctx) {
+    ctx.before = "before";
+    bar(ctx);
+    ctx.after = "after";
+}

--- a/cli-synapse/src/test/resources/ballerina/property5/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property5/main.bal
@@ -2,8 +2,8 @@ import ballerina/http;
 
 public listener http:Listener httpListener = new (8080);
 
-service /HelloWorld on httpListener {
-    resource function get chain() returns http:Response {
+service /chain on httpListener {
+    resource function get run() returns http:Response {
         http:Response response = new;
         Context ctx = {};
         foo(ctx);

--- a/cli-synapse/src/test/resources/ballerina/property5/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property5/types.bal
@@ -1,0 +1,6 @@
+public type Context record {|
+    string barProp1?;
+    int barProp2?;
+    string before?;
+    string after?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/property6/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property6/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property6"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property6/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/property6/functions.bal
@@ -1,11 +1,8 @@
-function baz(Context ctx) {
-    ctx.str = "Hello world";
-}
-
 function bar(Context ctx) {
-    baz(ctx);
+    ctx.shared = "from-bar";
 }
 
 function foo(Context ctx) {
     bar(ctx);
+    ctx.shared = "from-foo";
 }

--- a/cli-synapse/src/test/resources/ballerina/property6/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property6/main.bal
@@ -2,8 +2,8 @@ import ballerina/http;
 
 public listener http:Listener httpListener = new (8080);
 
-service /HelloWorld on httpListener {
-    resource function get chain() returns http:Response {
+service /chain on httpListener {
+    resource function get run() returns http:Response {
         http:Response response = new;
         Context ctx = {};
         foo(ctx);

--- a/cli-synapse/src/test/resources/ballerina/property6/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property6/types.bal
@@ -1,0 +1,3 @@
+public type Context record {|
+    string shared?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/property7/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property7/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property7"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property7/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/property7/functions.bal
@@ -1,11 +1,8 @@
-function baz(Context ctx) {
-    ctx.str = "Hello world";
-}
-
 function bar(Context ctx) {
-    baz(ctx);
+    ctx.shared = 99;
 }
 
 function foo(Context ctx) {
     bar(ctx);
+    ctx.shared = "from-foo";
 }

--- a/cli-synapse/src/test/resources/ballerina/property7/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property7/main.bal
@@ -2,8 +2,8 @@ import ballerina/http;
 
 public listener http:Listener httpListener = new (8080);
 
-service /HelloWorld on httpListener {
-    resource function get chain() returns http:Response {
+service /chain on httpListener {
+    resource function get run() returns http:Response {
         http:Response response = new;
         Context ctx = {};
         foo(ctx);

--- a/cli-synapse/src/test/resources/ballerina/property7/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property7/types.bal
@@ -1,0 +1,3 @@
+public type Context record {|
+    int|string shared?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/property8/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property8/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property8"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property8/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property8/main.bal
@@ -1,0 +1,14 @@
+import ballerina/http;
+
+public listener http:Listener httpListener = new (8080);
+
+service /prop on httpListener {
+    resource function get run() returns http:Response {
+        http:Response response = new;
+        Context ctx = {};
+        ctx.temp = "value";
+        ctx.temp = ();
+        response.setPayload({"done": true});
+        return response;
+    }
+}

--- a/cli-synapse/src/test/resources/ballerina/property8/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property8/types.bal
@@ -1,0 +1,3 @@
+public type Context record {|
+    string temp?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/property9/Ballerina.toml
+++ b/cli-synapse/src/test/resources/ballerina/property9/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testOrg"
+name = "property9"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/cli-synapse/src/test/resources/ballerina/property9/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/property9/main.bal
@@ -1,0 +1,13 @@
+import ballerina/http;
+
+public listener http:Listener httpListener = new (8080);
+
+service /syn on httpListener {
+    resource function get r() returns http:Response {
+        http:Response response = new;
+        Context ctx = {};
+        ctx.synProp = "hi";
+        ctx.defProp = 7;
+        return response;
+    }
+}

--- a/cli-synapse/src/test/resources/ballerina/property9/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/property9/types.bal
@@ -1,0 +1,4 @@
+public type Context record {|
+    string synProp?;
+    int defProp?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/sequence1/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence1/functions.bal
@@ -1,3 +1,3 @@
-function sequence() {
-    string str = "Hello world";
+function sequence(Context ctx) {
+    ctx.str = "Hello world";
 }

--- a/cli-synapse/src/test/resources/ballerina/sequence1/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence1/main.bal
@@ -4,9 +4,10 @@ public listener http:Listener httpListener = new (8080);
 
 service /HelloWorld on httpListener {
     resource function get status/[string name]/[string id](string q) returns http:Response {
+        Context ctx = {};
         http:Response response = new;
         response.setPayload({"Hello": "World"});
-        sequence();
+        sequence(ctx);
         return response;
     }
 }

--- a/cli-synapse/src/test/resources/ballerina/sequence1/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence1/types.bal
@@ -1,0 +1,3 @@
+public type Context record {|
+    string str?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/sequence2/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence2/functions.bal
@@ -1,8 +1,8 @@
-function foo() {
-    int i = 23;
+function foo(Context ctx) {
+    ctx.i = 23;
 }
 
-function sequence() {
-    string str = "Hello world";
-    foo();
+function sequence(Context ctx) {
+    ctx.str = "Hello world";
+    foo(ctx);
 }

--- a/cli-synapse/src/test/resources/ballerina/sequence2/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence2/main.bal
@@ -4,9 +4,10 @@ public listener http:Listener httpListener = new (8080);
 
 service /HelloWorld on httpListener {
     resource function get status/[string name]/[string id](string q) returns http:Response {
+        Context ctx = {};
         http:Response response = new;
         response.setPayload({"Hello": "World"});
-        sequence();
+        sequence(ctx);
         return response;
     }
 }

--- a/cli-synapse/src/test/resources/ballerina/sequence2/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence2/types.bal
@@ -1,0 +1,4 @@
+public type Context record {|
+    int i?;
+    string str?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/sequence3/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence3/functions.bal
@@ -1,8 +1,8 @@
-function bar() {
-    string str = "Hello world";
+function bar(Context ctx) {
+    ctx.str = "Hello world";
 }
 
-function foo() {
-    int i = 23;
-    bar();
+function foo(Context ctx) {
+    ctx.i = 23;
+    bar(ctx);
 }

--- a/cli-synapse/src/test/resources/ballerina/sequence3/functions.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence3/functions.bal
@@ -1,10 +1,8 @@
-import ballerina/http;
-
 function bar() {
     string str = "Hello world";
 }
 
-function foo(http:Response response) {
+function foo() {
     int i = 23;
     bar();
 }

--- a/cli-synapse/src/test/resources/ballerina/sequence3/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence3/main.bal
@@ -4,16 +4,18 @@ public listener http:Listener httpListener = new (8080);
 
 service /HelloWorld on httpListener {
     resource function get status/[string name]/[string id](string q) returns http:Response {
+        Context ctx = {};
         http:Response response = new;
         response.setPayload({"Hello": "World"});
-        foo();
+        foo(ctx);
         return response;
     }
 
     resource function get id1/[string id]() returns http:Response {
+        Context ctx = {};
         http:Response response = new;
         response.setPayload({"Hello": "World"});
-        bar();
+        bar(ctx);
         return response;
     }
 }

--- a/cli-synapse/src/test/resources/ballerina/sequence3/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence3/main.bal
@@ -6,7 +6,7 @@ service /HelloWorld on httpListener {
     resource function get status/[string name]/[string id](string q) returns http:Response {
         http:Response response = new;
         response.setPayload({"Hello": "World"});
-        foo(response);
+        foo();
         return response;
     }
 

--- a/cli-synapse/src/test/resources/ballerina/sequence3/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence3/types.bal
@@ -1,0 +1,4 @@
+public type Context record {|
+    string str?;
+    int i?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/sequence5/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence5/types.bal
@@ -1,0 +1,3 @@
+public type Context record {|
+    string str?;
+|};

--- a/cli-synapse/src/test/resources/ballerina/sequence9/main.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence9/main.bal
@@ -5,9 +5,10 @@ public listener http:Listener httpListener = new (8080);
 service /HelloWorld on httpListener {
     resource function get orders() returns http:Response {
         http:Response response = new;
-        string before = "before";
+        Context ctx = {};
+        ctx.before = "before";
         response.setPayload({"id": "001"});
-        string after = "after";
+        ctx.after = "after";
         return response;
     }
 }

--- a/cli-synapse/src/test/resources/ballerina/sequence9/types.bal
+++ b/cli-synapse/src/test/resources/ballerina/sequence9/types.bal
@@ -1,0 +1,4 @@
+public type Context record {|
+    string before?;
+    string after?;
+|};

--- a/cli-synapse/src/test/resources/synapse/property1/seq.xml
+++ b/cli-synapse/src/test/resources/synapse/property1/seq.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence name="seq" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <property name="greeting" scope="default" type="STRING" value="&quot;Hello&quot;"/>
+    <property name="count" scope="default" type="INTEGER" value="5"/>
+    <property name="enabled" scope="default" type="BOOLEAN" value="true"/>
+</sequence>

--- a/cli-synapse/src/test/resources/synapse/property2/bar.xml
+++ b/cli-synapse/src/test/resources/synapse/property2/bar.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence name="bar" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <property name="barProp1" scope="default" type="STRING" value="&quot;bar-one&quot;"/>
+    <property name="barProp2" scope="default" type="INTEGER" value="10"/>
+</sequence>

--- a/cli-synapse/src/test/resources/synapse/property2/foo.xml
+++ b/cli-synapse/src/test/resources/synapse/property2/foo.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence name="foo" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <property name="before" scope="default" type="STRING" value="&quot;before&quot;"/>
+    <sequence key="bar"/>
+    <property name="after" scope="default" type="STRING" value="&quot;after&quot;"/>
+</sequence>

--- a/cli-synapse/src/test/resources/synapse/property3/api.xml
+++ b/cli-synapse/src/test/resources/synapse/property3/api.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/orders" name="OrdersApi" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/list">
+        <inSequence>
+            <property name="prop1" scope="default" type="STRING" value="&quot;list&quot;"/>
+            <property name="r1only" scope="default" type="INTEGER" value="1"/>
+            <payloadFactory media-type="json" template-type="default">
+                <format>{"resource":"list"}</format>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+    <resource methods="POST" uri-template="/create">
+        <inSequence>
+            <property name="prop1" scope="default" type="STRING" value="&quot;create&quot;"/>
+            <property name="r2only" scope="default" type="BOOLEAN" value="true"/>
+            <payloadFactory media-type="json" template-type="default">
+                <format>{"resource":"create"}</format>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/synapse/property4/api.xml
+++ b/cli-synapse/src/test/resources/synapse/property4/api.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/orders" name="OrdersApi" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/list">
+        <inSequence>
+            <property name="prop1" scope="default" type="STRING" value="&quot;list&quot;"/>
+            <property name="r1only" scope="default" type="INTEGER" value="1"/>
+            <payloadFactory media-type="json" template-type="default">
+                <format>{"resource":"list"}</format>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+    <resource methods="POST" uri-template="/create">
+        <inSequence>
+            <property name="prop1" scope="default" type="INTEGER" value="55"/>
+            <property name="r2only" scope="default" type="BOOLEAN" value="true"/>
+            <payloadFactory media-type="json" template-type="default">
+                <format>{"resource":"create"}</format>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/synapse/property5/api.xml
+++ b/cli-synapse/src/test/resources/synapse/property5/api.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/chain" name="ChainApi" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/run">
+        <inSequence>
+            <sequence key="foo"/>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/synapse/property5/bar.xml
+++ b/cli-synapse/src/test/resources/synapse/property5/bar.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence name="bar" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <property name="barProp1" scope="default" type="STRING" value="&quot;bar-one&quot;"/>
+    <property name="barProp2" scope="default" type="INTEGER" value="10"/>
+</sequence>

--- a/cli-synapse/src/test/resources/synapse/property5/foo.xml
+++ b/cli-synapse/src/test/resources/synapse/property5/foo.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence name="foo" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <property name="before" scope="default" type="STRING" value="&quot;before&quot;"/>
+    <sequence key="bar"/>
+    <property name="after" scope="default" type="STRING" value="&quot;after&quot;"/>
+</sequence>

--- a/cli-synapse/src/test/resources/synapse/property6/api.xml
+++ b/cli-synapse/src/test/resources/synapse/property6/api.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/chain" name="ChainApi" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/run">
+        <inSequence>
+            <sequence key="foo"/>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/synapse/property6/bar.xml
+++ b/cli-synapse/src/test/resources/synapse/property6/bar.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence name="bar" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <property name="shared" scope="default" type="STRING" value="&quot;from-bar&quot;"/>
+</sequence>

--- a/cli-synapse/src/test/resources/synapse/property6/foo.xml
+++ b/cli-synapse/src/test/resources/synapse/property6/foo.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sequence name="foo" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
-    <property name="i" scope="default" type="INTEGER" value="23"/>
+    <sequence key="bar"/>
+    <property name="shared" scope="default" type="STRING" value="&quot;from-foo&quot;"/>
 </sequence>

--- a/cli-synapse/src/test/resources/synapse/property7/api.xml
+++ b/cli-synapse/src/test/resources/synapse/property7/api.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/chain" name="ChainApi" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/run">
+        <inSequence>
+            <sequence key="foo"/>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/synapse/property7/bar.xml
+++ b/cli-synapse/src/test/resources/synapse/property7/bar.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence name="bar" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <property name="shared" scope="default" type="INTEGER" value="99"/>
+</sequence>

--- a/cli-synapse/src/test/resources/synapse/property7/foo.xml
+++ b/cli-synapse/src/test/resources/synapse/property7/foo.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sequence name="foo" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
-    <property name="i" scope="default" type="INTEGER" value="23"/>
+    <sequence key="bar"/>
+    <property name="shared" scope="default" type="STRING" value="&quot;from-foo&quot;"/>
 </sequence>

--- a/cli-synapse/src/test/resources/synapse/property8/api.xml
+++ b/cli-synapse/src/test/resources/synapse/property8/api.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/prop" name="RemoveApi" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/run">
+        <inSequence>
+            <property name="temp" scope="default" type="STRING" value="&quot;value&quot;"/>
+            <property name="temp" scope="default" action="remove"/>
+            <payloadFactory media-type="json" template-type="default">
+                <format>{"done":true}</format>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/synapse/property9/api.xml
+++ b/cli-synapse/src/test/resources/synapse/property9/api.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/syn" name="SynApi" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/r">
+        <inSequence>
+            <property name="synProp" scope="synapse" type="STRING" value="&quot;hi&quot;"/>
+            <property name="defProp" scope="default" type="INTEGER" value="7"/>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/synapse/sequence3/foo.xml
+++ b/cli-synapse/src/test/resources/synapse/sequence3/foo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sequence name="foo" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
-    <property name="i" scope="default" type="INT" value="23"/>
+    <property name="i" scope="default" type="INTEGER" value="23"/>
     <sequence key="bar"/>
     <payloadFactory media-type="json" template-type="default">
         <format>{"id": "002"}</format>

--- a/cli-synapse/src/test/resources/testng.xml
+++ b/cli-synapse/src/test/resources/testng.xml
@@ -4,6 +4,7 @@
         <classes>
             <class name="synapse.converter.SynapseProjectConversionTest"/>
             <class name="synapse.converter.SynapseImportsTest"/>
+            <class name="synapse.converter.PropertyScopeTest"/>
             <class name="synapse.model.TopologicalSorterTest"/>
             <class name="synapse.model.DependencyResolverTest"/>
             <class name="synapse.model.DependencyGraphTest"/>

--- a/cli-synapse/src/test/resources/unsupported-property/axis2-remove/api.xml
+++ b/cli-synapse/src/test/resources/unsupported-property/axis2-remove/api.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/x" name="Axis2Remove" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/r">
+        <inSequence>
+            <property name="HTTP_SC" scope="axis2" type="STRING" value="201" action="remove"/>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/unsupported-property/transport-remove/api.xml
+++ b/cli-synapse/src/test/resources/unsupported-property/transport-remove/api.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/x" name="TransportRemove" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/r">
+        <inSequence>
+            <property name="HTTP_SC" scope="transport" type="STRING" value="200" action="remove"/>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/cli-synapse/src/test/resources/unsupported-property/unknown-scope/api.xml
+++ b/cli-synapse/src/test/resources/unsupported-property/unknown-scope/api.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api context="/x" name="UnknownScope" xmlns="http://ws.apache.org/ns/synapse">
+    <resource methods="GET" uri-template="/r">
+        <inSequence>
+            <property name="opProp" scope="operation" type="STRING" value="&quot;x&quot;"/>
+            <respond/>
+        </inSequence>
+        <faultSequence/>
+    </resource>
+</api>

--- a/synapse/src/main/java/synapse/converter/BIRConverter.java
+++ b/synapse/src/main/java/synapse/converter/BIRConverter.java
@@ -132,18 +132,27 @@ public interface BIRConverter<C> {
     }
 
     /**
-     * Ensures a {@code response} is in scope, declaring
-     * {@code http:Response response = new;} at the top
-     * of the body when one is not already available (neither a parameter nor an
-     * earlier declaration).
+     * Ensures a {@code response} is in scope. When one is not already available
+     * (neither a parameter nor
+     * an earlier declaration), a resource body declares
+     * {@code http:Response response = new;} at the top,
+     * whereas a sequence body instead takes the response as a parameter it mutates
+     * in place — recorded via
+     * {@link ScopeContext#setResponseParam(boolean)} and realised as a function
+     * parameter once the body is
+     * converted.
      */
     private static void ensureResponseAvailable(ScopeContext context) {
         context.importStatements().add(HTTP_IMPORT);
         if (context.responseAvailable()) {
             return;
         }
-        context.statements().add(0, new Statement.BallerinaStatement("http:Response response = new;"));
-        context.setRespondInitialized(true);
+        if (context.isWithinResource()) {
+            context.statements().add(0, new Statement.BallerinaStatement("http:Response response = new;"));
+            context.setRespondInitialized(true);
+        } else {
+            context.setResponseParam(true);
+        }
     }
 
     /**
@@ -218,55 +227,40 @@ public interface BIRConverter<C> {
     /**
      * Converts a top-level Synapse {@code <sequence>} into a Ballerina function
      * whose body is the
-     * converted mediator flow. A sequence holding a {@code <payloadFactory>}
-     * becomes a function taking an
-     * {@code http:Response response} parameter, which it mutates in place (setting
-     * the payload) rather than
-     * returning. The function's return type is driven by the converted mediators:
-     * unless they yield a
-     * non-{@code nil} {@code returnType}, the function is {@code nil}-returning.
-     * A sequence without a {@code <payloadFactory>} is parameterless.
+     * converted mediator flow. Whether the function takes an
+     * {@code http:Response response} parameter and
+     * whether it responds both fall out of converting the body rather than a
+     * separate pre-scan: when
+     * conversion reaches a {@code <payloadFactory>} (directly or down a call chain)
+     * the sequence takes a
+     * {@code response} parameter it mutates in place instead of returning, and an
+     * unreached payloadFactory
+     * (e.g. after a {@code <respond>}) leaves the function parameterless. The
+     * function's return type is
+     * likewise driven by the converted mediators: unless they yield a
+     * non-{@code nil} {@code returnType},
+     * the function is {@code nil}-returning.
      */
     class SequenceConverter implements BIRConverter<ConversionContext> {
 
         @Override
         public void convert(SynapseNode node, ConversionContext context) {
             Sequence sequence = (Sequence) node;
-            boolean containsPayloadFactory = containsPayloadFactory(sequence, context);
-            List<Parameter> params = containsPayloadFactory
-                    ? List.of(new Parameter("response", new TypeDesc.BallerinaType("http:Response")))
-                    : List.of();
-
-            SequenceContext sequenceContext = new SequenceContext(context, containsPayloadFactory);
-            if (containsPayloadFactory) {
-                sequenceContext.importStatements().add(HTTP_IMPORT);
-            }
+            SequenceContext sequenceContext = new SequenceContext(context);
             convertMediators(sequence.mediators(), sequenceContext);
+            boolean containsPayloadFactory = sequenceContext.hasResponseParam();
             context.addSequenceMetadata(new ConversionContext.SequenceMetadata(
                     sequence.name(), sequenceContext.isResponded(), containsPayloadFactory));
             context.addImports(ConversionContext.FUNCTIONS_BAL_FILE, sequenceContext.importStatements());
+            List<Parameter> params = containsPayloadFactory
+                    ? List.of(new Parameter("response", new TypeDesc.BallerinaType("http:Response")))
+                    : List.of();
             TypeDesc returnType = sequenceContext.returnType();
             List<Statement> body = sequenceContext.statements();
             Function function = returnType == BuiltinType.NIL
                     ? new Function(sequence.name(), params, body)
                     : new Function(sequence.name(), params, returnType, body);
             context.addFunction(function);
-        }
-
-        private static boolean containsPayloadFactory(Sequence sequence, ConversionContext context) {
-            for (SynapseNode mediator : sequence.mediators()) {
-                if (mediator.kind() == Kind.PAYLOAD_FACTORY) {
-                    return true;
-                }
-                if (mediator instanceof SequenceMediator sequenceMediator) {
-                    ConversionContext.SequenceMetadata referenced =
-                            context.sequenceMetadata(sequenceMediator.key()).orElse(null);
-                    if (referenced != null && referenced.containsPayloadFactory()) {
-                        return true;
-                    }
-                }
-            }
-            return false;
         }
     }
 

--- a/synapse/src/main/java/synapse/converter/BIRConverter.java
+++ b/synapse/src/main/java/synapse/converter/BIRConverter.java
@@ -224,18 +224,15 @@ public interface BIRConverter<C> {
      * the payload) rather than
      * returning. The function's return type is driven by the converted mediators:
      * unless they yield a
-     * non-{@code nil} {@code returnType}, the function is {@code nil}-returning
-     * (see line 239). A sequence
-     * without a {@code <payloadFactory>} is parameterless.
+     * non-{@code nil} {@code returnType}, the function is {@code nil}-returning.
+     * A sequence without a {@code <payloadFactory>} is parameterless.
      */
     class SequenceConverter implements BIRConverter<ConversionContext> {
 
         @Override
         public void convert(SynapseNode node, ConversionContext context) {
             Sequence sequence = (Sequence) node;
-            ConversionContext.SequenceMetadata metadata = buildSequenceMetadata(sequence, context);
-            context.addSequenceMetadata(metadata);
-            boolean containsPayloadFactory = metadata.containsPayloadFactory();
+            boolean containsPayloadFactory = containsPayloadFactory(sequence, context);
             List<Parameter> params = containsPayloadFactory
                     ? List.of(new Parameter("response", new TypeDesc.BallerinaType("http:Response")))
                     : List.of();
@@ -245,6 +242,8 @@ public interface BIRConverter<C> {
                 sequenceContext.importStatements().add(HTTP_IMPORT);
             }
             convertMediators(sequence.mediators(), sequenceContext);
+            context.addSequenceMetadata(new ConversionContext.SequenceMetadata(
+                    sequence.name(), sequenceContext.isResponded(), containsPayloadFactory));
             context.addImports(ConversionContext.FUNCTIONS_BAL_FILE, sequenceContext.importStatements());
             TypeDesc returnType = sequenceContext.returnType();
             List<Statement> body = sequenceContext.statements();
@@ -254,26 +253,20 @@ public interface BIRConverter<C> {
             context.addFunction(function);
         }
 
-        private static ConversionContext.SequenceMetadata buildSequenceMetadata(Sequence sequence,
-                ConversionContext context) {
-            boolean containsRespond = false;
-            boolean containsPayloadFactory = false;
+        private static boolean containsPayloadFactory(Sequence sequence, ConversionContext context) {
             for (SynapseNode mediator : sequence.mediators()) {
-                if (mediator.kind() == Kind.RESPOND) {
-                    containsRespond = true;
-                } else if (mediator.kind() == Kind.PAYLOAD_FACTORY) {
-                    containsPayloadFactory = true;
-                } else if (mediator instanceof SequenceMediator sequenceMediator) {
+                if (mediator.kind() == Kind.PAYLOAD_FACTORY) {
+                    return true;
+                }
+                if (mediator instanceof SequenceMediator sequenceMediator) {
                     ConversionContext.SequenceMetadata referenced =
                             context.sequenceMetadata(sequenceMediator.key()).orElse(null);
-                    if (referenced != null) {
-                        containsRespond = containsRespond || referenced.containsRespond();
-                        containsPayloadFactory = containsPayloadFactory || referenced.containsPayloadFactory();
+                    if (referenced != null && referenced.containsPayloadFactory()) {
+                        return true;
                     }
                 }
             }
-            return new ConversionContext.SequenceMetadata(sequence.name(), containsRespond,
-                    containsPayloadFactory);
+            return false;
         }
     }
 

--- a/synapse/src/main/java/synapse/converter/BIRConverter.java
+++ b/synapse/src/main/java/synapse/converter/BIRConverter.java
@@ -109,19 +109,6 @@ public interface BIRConverter<C> {
         }
     }
 
-    /**
-     * Emits the {@code return response;} for a respond in {@code context},
-     * initialising the
-     * {@code http:Response} first, and recording {@code http:Response} as the
-     * scope's
-     * {@link ScopeContext#returnType()}. Outside a resource body nothing is
-     * emitted: a sequence function
-     * stays {@code nil}-returning and its respond is realised at the resource that
-     * calls it. Either way
-     * the scope is marked {@link ScopeContext#isResponded() responded}, since a
-     * respond is terminal and
-     * ends mediator conversion.
-     */
     private static void emitRespond(ScopeContext context) {
         context.setResponded(true);
         if (!context.isWithinResource()) {
@@ -131,17 +118,6 @@ public interface BIRConverter<C> {
         returnResponse(context);
     }
 
-    /**
-     * Ensures a {@code response} is in scope. When one is not already available
-     * (neither a parameter nor
-     * an earlier declaration), a resource body declares
-     * {@code http:Response response = new;} at the top,
-     * whereas a sequence body instead takes the response as a parameter it mutates
-     * in place — recorded via
-     * {@link ScopeContext#setResponseParam(boolean)} and realised as a function
-     * parameter once the body is
-     * converted.
-     */
     private static void ensureResponseAvailable(ScopeContext context) {
         context.importStatements().add(HTTP_IMPORT);
         if (context.responseAvailable()) {
@@ -155,11 +131,18 @@ public interface BIRConverter<C> {
         }
     }
 
-    /**
-     * Returns {@code response}, recording {@code http:Response} as the scope's
-     * {@link ScopeContext#returnType()}. Assumes a {@code response} is already in
-     * scope.
-     */
+    private static void ensureContextAvailable(ScopeContext context) {
+        if (context.contextAvailable()) {
+            return;
+        }
+        if (context.isWithinResource()) {
+            context.statements().add(0, new Statement.BallerinaStatement("Context ctx = {};"));
+            context.setContextInitialized(true);
+        } else {
+            context.setContextParam(true);
+        }
+    }
+
     private static void returnResponse(ScopeContext context) {
         context.statements().add(new Statement.Return<>(Optional.of(new Expression.VariableReference("response"))));
         context.setReturnType(new TypeDesc.BallerinaType("http:Response"));
@@ -249,12 +232,17 @@ public interface BIRConverter<C> {
             SequenceContext sequenceContext = new SequenceContext(context);
             convertMediators(sequence.mediators(), sequenceContext);
             boolean containsPayloadFactory = sequenceContext.hasResponseParam();
+            boolean usesContext = sequenceContext.hasContextParam();
             context.addSequenceMetadata(new ConversionContext.SequenceMetadata(
-                    sequence.name(), sequenceContext.isResponded(), containsPayloadFactory));
+                    sequence.name(), sequenceContext.isResponded(), containsPayloadFactory, usesContext));
             context.addImports(ConversionContext.FUNCTIONS_BAL_FILE, sequenceContext.importStatements());
-            List<Parameter> params = containsPayloadFactory
-                    ? List.of(new Parameter("response", new TypeDesc.BallerinaType("http:Response")))
-                    : List.of();
+            List<Parameter> params = new ArrayList<>();
+            if (usesContext) {
+                params.add(new Parameter("ctx", new TypeDesc.BallerinaType("Context")));
+            }
+            if (containsPayloadFactory) {
+                params.add(new Parameter("response", new TypeDesc.BallerinaType("http:Response")));
+            }
             TypeDesc returnType = sequenceContext.returnType();
             List<Statement> body = sequenceContext.statements();
             Function function = returnType == BuiltinType.NIL
@@ -282,10 +270,14 @@ public interface BIRConverter<C> {
             SequenceMediator sequenceMediator = (SequenceMediator) node;
             ConversionContext.SequenceMetadata metadata = context.shared().sequenceMetadata(sequenceMediator.key())
                     .orElse(null);
-            List<Expression> args = List.of();
+            List<Expression> args = new ArrayList<>();
+            if (metadata != null && metadata.usesContext()) {
+                ensureContextAvailable(context);
+                args.add(new Expression.VariableReference("ctx"));
+            }
             if (metadata != null && metadata.containsPayloadFactory()) {
                 ensureResponseAvailable(context);
-                args = List.of(new Expression.VariableReference("response"));
+                args.add(new Expression.VariableReference("response"));
             }
             context.statements().add(new Statement.CallStatement(
                     new Expression.FunctionCall(sequenceMediator.key(), args)));
@@ -330,6 +322,7 @@ public interface BIRConverter<C> {
 
         private static final String TRANSPORT_SCOPE = "transport";
         private static final String AXIS2_SCOPE = "axis2";
+        private static final String REMOVE_ACTION = "remove";
 
         @Override
         public void convert(SynapseNode node, ScopeContext context) {
@@ -337,14 +330,25 @@ public interface BIRConverter<C> {
         }
 
         private static void convertProperty(Property property, ScopeContext context) {
-            String statement = switch (property.scope()) {
-                case TRANSPORT_SCOPE -> "response.setHeader(\"" + property.name() + "\", \""
-                        + property.value() + "\");";
-                case AXIS2_SCOPE -> "response.statusCode = " + property.value() + ";";
-                default -> toBallerinaType(property.type()) + " " + property.name() + " = "
-                        + property.value() + ";";
-            };
-            context.statements().add(new Statement.BallerinaStatement(statement));
+            switch (property.scope()) {
+                case TRANSPORT_SCOPE -> context.statements().add(new Statement.BallerinaStatement(
+                        "response.setHeader(\"" + property.name() + "\", \"" + property.value() + "\");"));
+                case AXIS2_SCOPE -> context.statements().add(new Statement.BallerinaStatement(
+                        "response.statusCode = " + property.value() + ";"));
+                default -> convertDefaultProperty(property, context);
+            }
+        }
+
+        private static void convertDefaultProperty(Property property, ScopeContext context) {
+            ensureContextAvailable(context);
+            if (REMOVE_ACTION.equals(property.action())) {
+                context.statements().add(new Statement.BallerinaStatement(
+                        "ctx." + property.name() + " = " + BuiltinType.NIL + ";"));
+                return;
+            }
+            context.shared().addProperty(property.name(), toBallerinaType(property.type()), property.scope());
+            context.statements().add(new Statement.BallerinaStatement(
+                    "ctx." + property.name() + " = " + property.value() + ";"));
         }
 
         private static String toBallerinaType(String synapseType) {

--- a/synapse/src/main/java/synapse/converter/BIRConverter.java
+++ b/synapse/src/main/java/synapse/converter/BIRConverter.java
@@ -258,14 +258,12 @@ public interface BIRConverter<C> {
                 ConversionContext context) {
             boolean containsRespond = false;
             boolean containsPayloadFactory = false;
-            List<String> referencedSequences = new ArrayList<>();
             for (SynapseNode mediator : sequence.mediators()) {
                 if (mediator.kind() == Kind.RESPOND) {
                     containsRespond = true;
                 } else if (mediator.kind() == Kind.PAYLOAD_FACTORY) {
                     containsPayloadFactory = true;
                 } else if (mediator instanceof SequenceMediator sequenceMediator) {
-                    referencedSequences.add(sequenceMediator.key());
                     ConversionContext.SequenceMetadata referenced =
                             context.sequenceMetadata(sequenceMediator.key()).orElse(null);
                     if (referenced != null) {
@@ -275,7 +273,7 @@ public interface BIRConverter<C> {
                 }
             }
             return new ConversionContext.SequenceMetadata(sequence.name(), containsRespond,
-                    containsPayloadFactory, referencedSequences);
+                    containsPayloadFactory);
         }
     }
 

--- a/synapse/src/main/java/synapse/converter/BIRConverter.java
+++ b/synapse/src/main/java/synapse/converter/BIRConverter.java
@@ -322,6 +322,8 @@ public interface BIRConverter<C> {
 
         private static final String TRANSPORT_SCOPE = "transport";
         private static final String AXIS2_SCOPE = "axis2";
+        private static final String DEFAULT_SCOPE = "default";
+        private static final String SYNAPSE_SCOPE = "synapse";
         private static final String REMOVE_ACTION = "remove";
 
         @Override
@@ -331,11 +333,31 @@ public interface BIRConverter<C> {
 
         private static void convertProperty(Property property, ScopeContext context) {
             switch (property.scope()) {
-                case TRANSPORT_SCOPE -> context.statements().add(new Statement.BallerinaStatement(
-                        "response.setHeader(\"" + property.name() + "\", \"" + property.value() + "\");"));
-                case AXIS2_SCOPE -> context.statements().add(new Statement.BallerinaStatement(
-                        "response.statusCode = " + property.value() + ";"));
-                default -> convertDefaultProperty(property, context);
+                case TRANSPORT_SCOPE -> {
+                    rejectRemoveAction(property);
+                    context.statements().add(new Statement.BallerinaStatement(
+                            "response.setHeader(\"" + property.name() + "\", \"" + property.value() + "\");"));
+                }
+                case AXIS2_SCOPE -> {
+                    rejectRemoveAction(property);
+                    context.statements().add(new Statement.BallerinaStatement(
+                            "response.statusCode = " + property.value() + ";"));
+                }
+                case DEFAULT_SCOPE, SYNAPSE_SCOPE -> convertDefaultProperty(property, context);
+                default -> throw new UnsupportedOperationException("The '" + property.scope()
+                        + "' scope is not supported for property '" + property.name() + "'.");
+            }
+        }
+
+        /**
+         * The {@code remove} action is only supported in the default scope, where it clears a
+         * {@code Context} field. Removing a transport header or an axis2 property has no equivalent in
+         * the generated code yet, so reject it as unsupported rather than emit a misleading assignment.
+         */
+        private static void rejectRemoveAction(Property property) {
+            if (REMOVE_ACTION.equals(property.action())) {
+                throw new UnsupportedOperationException("The 'remove' action is not supported for property '"
+                        + property.name() + "' in the '" + property.scope() + "' scope.");
             }
         }
 

--- a/synapse/src/main/java/synapse/converter/ConversionContext.java
+++ b/synapse/src/main/java/synapse/converter/ConversionContext.java
@@ -129,9 +129,8 @@ public class ConversionContext {
     }
 
     // Pre-gathered facts about a <sequence>. containsRespond and containsPayloadFactory are transitive:
-    // also true when a referencedSequences entry responds / sets a payload (resolved by propagation),
+    // also true when a referenced sequence responds / sets a payload (resolved by propagation),
     // so a call site can decide across chains whether to return a response or pass one in.
-    public record SequenceMetadata(String name, boolean containsRespond, boolean containsPayloadFactory,
-                                   List<String> referencedSequences) {
+    public record SequenceMetadata(String name, boolean containsRespond, boolean containsPayloadFactory) {
     }
 }

--- a/synapse/src/main/java/synapse/converter/ConversionContext.java
+++ b/synapse/src/main/java/synapse/converter/ConversionContext.java
@@ -26,6 +26,7 @@ import synapse.model.DependencyGraph;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,7 @@ public class ConversionContext {
 
     private final Map<String, SequenceMetadata> sequenceMetadata = new HashMap<>();
     private final Map<String, Set<Import>> importsByFile = new HashMap<>();
+    private final Map<String, PropertyInfo> properties = new LinkedHashMap<>();
 
     private DependencyGraph dependencyGraph;
 
@@ -106,6 +108,29 @@ public class ConversionContext {
     }
 
     /**
+     * Registers a Synapse property so it becomes a field of the generated {@code Context} record. The
+     * types seen for a name are accumulated and its scope retained; the {@code Context} record
+     * aggregates every property across the whole project, so this map is populated as artifacts are
+     * converted (leaf-first) and preserved across {@link #clearArtifactOutput()}. A name declared with
+     * more than one type across the project therefore records every type — the field becomes a union of
+     * them — while the scope of the first registration is kept.
+     */
+    public void addProperty(String name, String type, String scope) {
+        PropertyInfo existing = properties.get(name);
+        if (existing == null) {
+            Set<String> types = new LinkedHashSet<>();
+            types.add(type);
+            properties.put(name, new PropertyInfo(types, scope));
+        } else {
+            existing.types().add(type);
+        }
+    }
+
+    public Map<String, PropertyInfo> properties() {
+        return properties;
+    }
+
+    /**
      * Records the imports needed by a generated {@code .bal} file, accumulated across every artifact
      * flushed into that file. Deduplicated, and preserved across {@link #clearArtifactOutput()} since a
      * later artifact may add imports to a file an earlier one already created.
@@ -128,13 +153,23 @@ public class ConversionContext {
         records.clear();
     }
 
-    // Facts about a <sequence>, recorded once it has been converted. Both fall out of the conversion
-    // itself: containsRespond is whether a respond was emitted into the sequence's scope, and
+    // Facts about a <sequence>, recorded once it has been converted, all falling out of the conversion
+    // itself: containsRespond is whether a respond was emitted into the sequence's scope,
     // containsPayloadFactory whether the sequence ended up taking an http:Response parameter to set a
-    // payload on. Both are transitive — reaching a called sequence that responds / sets a payload
-    // propagates during conversion — so a call site can decide across chains whether to return a
-    // response or pass one in. Only mediators actually reached count: a payloadFactory left unreached
-    // after a respond, say, is not recorded.
-    public record SequenceMetadata(String name, boolean containsRespond, boolean containsPayloadFactory) {
+    // payload on, and usesContext whether it ended up taking a Context ctx parameter to set default
+    // properties on. All are transitive — reaching a called sequence that responds / sets a payload /
+    // sets a property propagates during conversion — so a call site can decide across chains whether to
+    // return a response or pass one in, and whether to pass ctx. Only mediators actually reached count:
+    // a payloadFactory left unreached after a respond, say, is not recorded.
+    public record SequenceMetadata(String name, boolean containsRespond, boolean containsPayloadFactory,
+                                   boolean usesContext) {
+    }
+
+    // Types and scope of a Synapse property, retained per property name so the generated Context record
+    // can declare a field of the right type. More than one type appears when the same name is declared
+    // with different types across the project, and the field becomes a union of them. Scope is kept for
+    // future non-default scopes even though only default-scope properties currently become Context
+    // fields.
+    public record PropertyInfo(Set<String> types, String scope) {
     }
 }

--- a/synapse/src/main/java/synapse/converter/ConversionContext.java
+++ b/synapse/src/main/java/synapse/converter/ConversionContext.java
@@ -128,11 +128,13 @@ public class ConversionContext {
         records.clear();
     }
 
-    // Facts about a <sequence>, recorded once it has been converted. Both are transitive: also true
-    // when a referenced sequence responds / sets a payload, so a call site can decide across chains
-    // whether to return a response or pass one in. containsPayloadFactory is pre-scanned (it decides
-    // the generated function's parameters); containsRespond falls out of the conversion itself, as
-    // whether a respond was emitted into the sequence's scope.
+    // Facts about a <sequence>, recorded once it has been converted. Both fall out of the conversion
+    // itself: containsRespond is whether a respond was emitted into the sequence's scope, and
+    // containsPayloadFactory whether the sequence ended up taking an http:Response parameter to set a
+    // payload on. Both are transitive — reaching a called sequence that responds / sets a payload
+    // propagates during conversion — so a call site can decide across chains whether to return a
+    // response or pass one in. Only mediators actually reached count: a payloadFactory left unreached
+    // after a respond, say, is not recorded.
     public record SequenceMetadata(String name, boolean containsRespond, boolean containsPayloadFactory) {
     }
 }

--- a/synapse/src/main/java/synapse/converter/ConversionContext.java
+++ b/synapse/src/main/java/synapse/converter/ConversionContext.java
@@ -128,9 +128,11 @@ public class ConversionContext {
         records.clear();
     }
 
-    // Pre-gathered facts about a <sequence>. containsRespond and containsPayloadFactory are transitive:
-    // also true when a referenced sequence responds / sets a payload (resolved by propagation),
-    // so a call site can decide across chains whether to return a response or pass one in.
+    // Facts about a <sequence>, recorded once it has been converted. Both are transitive: also true
+    // when a referenced sequence responds / sets a payload, so a call site can decide across chains
+    // whether to return a response or pass one in. containsPayloadFactory is pre-scanned (it decides
+    // the generated function's parameters); containsRespond falls out of the conversion itself, as
+    // whether a respond was emitted into the sequence's scope.
     public record SequenceMetadata(String name, boolean containsRespond, boolean containsPayloadFactory) {
     }
 }

--- a/synapse/src/main/java/synapse/converter/ConversionContext.java
+++ b/synapse/src/main/java/synapse/converter/ConversionContext.java
@@ -21,6 +21,7 @@ import common.BallerinaModel.Function;
 import common.BallerinaModel.Import;
 import common.BallerinaModel.ModuleTypeDef;
 import common.BallerinaModel.Service;
+import org.jetbrains.annotations.NotNull;
 import synapse.model.DependencyGraph;
 
 import java.util.ArrayList;
@@ -126,6 +127,7 @@ public class ConversionContext {
         }
     }
 
+    @NotNull
     public Map<String, PropertyInfo> properties() {
         return properties;
     }

--- a/synapse/src/main/java/synapse/converter/ScopeContext.java
+++ b/synapse/src/main/java/synapse/converter/ScopeContext.java
@@ -43,6 +43,8 @@ public abstract class ScopeContext {
     private final List<Import> importStatements = new ArrayList<>();
     private boolean responseParam;
     private boolean respondInitialized;
+    private boolean contextParam;
+    private boolean contextInitialized;
     private boolean responded;
     private TypeDesc returnType = BuiltinType.NIL;
 
@@ -111,6 +113,37 @@ public abstract class ScopeContext {
 
     public void setResponseParam(boolean responseParam) {
         this.responseParam = responseParam;
+    }
+
+    /**
+     * Whether a {@code ctx} holding the default-scope (Synapse) properties is in scope — either a
+     * {@code Context ctx} parameter (a sequence function that turned out to touch default properties,
+     * directly or down a call chain, see {@link #hasContextParam()}) or a {@code Context ctx} local
+     * declared in this scope. Default properties live for the duration of a request, so within a
+     * resource {@code ctx} is a local declared at the top, whereas a sequence receives it as a
+     * parameter it mutates in place.
+     */
+    public boolean contextAvailable() {
+        return contextParam || contextInitialized;
+    }
+
+    /**
+     * Whether the sequence function generated for this scope takes a {@code Context ctx} parameter,
+     * which it mutates in place. Set while converting the body — when a {@code <property>} in the
+     * default scope, or a call to a sequence that sets one, is reached in a sequence scope — and read
+     * back afterwards to shape the function's signature. A resource scope declares a {@code ctx} local
+     * instead, so this stays {@code false} there.
+     */
+    public boolean hasContextParam() {
+        return contextParam;
+    }
+
+    public void setContextParam(boolean contextParam) {
+        this.contextParam = contextParam;
+    }
+
+    public void setContextInitialized(boolean contextInitialized) {
+        this.contextInitialized = contextInitialized;
     }
 
     /**

--- a/synapse/src/main/java/synapse/converter/ScopeContext.java
+++ b/synapse/src/main/java/synapse/converter/ScopeContext.java
@@ -41,19 +41,14 @@ public abstract class ScopeContext {
     private final ConversionContext shared;
     private final List<Statement> statements = new ArrayList<>();
     private final List<Import> importStatements = new ArrayList<>();
-    private final boolean responseParam;
+    private boolean responseParam;
     private boolean respondInitialized;
     private boolean responded;
     private TypeDesc returnType = BuiltinType.NIL;
 
     protected ScopeContext(ConversionContext shared) {
-        this(shared, false);
-    }
-
-    protected ScopeContext(ConversionContext shared, boolean responseParam) {
         assert shared != null : "shared ConversionContext must not be null";
         this.shared = shared;
-        this.responseParam = responseParam;
     }
 
     public ConversionContext shared() {
@@ -91,13 +86,31 @@ public abstract class ScopeContext {
     /**
      * Whether a {@code response} is in scope to set a payload on or return — either
      * an
-     * {@code http:Response response} parameter (a sequence function generated for a
-     * {@code <sequence>}
-     * with a {@code <payloadFactory>}) or a {@code response} local already declared
-     * in this scope.
+     * {@code http:Response response} parameter (a sequence function that turned out
+     * to need one, see
+     * {@link #hasResponseParam()}) or a {@code response} local already declared in
+     * this scope.
      */
     public boolean responseAvailable() {
         return responseParam || respondInitialized;
+    }
+
+    /**
+     * Whether the sequence function generated for this scope takes an
+     * {@code http:Response response}
+     * parameter, which it mutates in place. Set while converting the body — when a
+     * {@code <payloadFactory>}, or a call to a sequence that sets a payload, is
+     * reached in a sequence
+     * scope — and read back afterwards to shape the function's signature. A resource
+     * scope declares a
+     * {@code response} local instead, so this stays {@code false} there.
+     */
+    public boolean hasResponseParam() {
+        return responseParam;
+    }
+
+    public void setResponseParam(boolean responseParam) {
+        this.responseParam = responseParam;
     }
 
     /**

--- a/synapse/src/main/java/synapse/converter/SequenceContext.java
+++ b/synapse/src/main/java/synapse/converter/SequenceContext.java
@@ -20,16 +20,17 @@ package synapse.converter;
 /**
  * Scope context for a top-level Synapse {@code <sequence>} body, converted into
  * a Ballerina function.
- * Unlike a resource body, {@link #isWithinResource()} remains {@code false};
- * however when the sequence
- * holds a {@code <payloadFactory>} its function takes an
- * {@code http:Response response} parameter, so
- * {@code responseParam} is set and {@link #responseAvailable()} reports a
- * response is in scope.
+ * Unlike a resource body, {@link #isWithinResource()} remains {@code false}; a
+ * response is never declared
+ * as a local here. Instead, if converting the body reaches a
+ * {@code <payloadFactory>} (directly or down a
+ * call chain), {@link #hasResponseParam()} is set and the generated function
+ * takes an
+ * {@code http:Response response} parameter that it mutates in place.
  */
 public final class SequenceContext extends ScopeContext {
 
-    public SequenceContext(ConversionContext shared, boolean responseParam) {
-        super(shared, responseParam);
+    public SequenceContext(ConversionContext shared) {
+        super(shared);
     }
 }

--- a/synapse/src/main/java/synapse/converter/SynapseConverter.java
+++ b/synapse/src/main/java/synapse/converter/SynapseConverter.java
@@ -25,7 +25,13 @@ import common.BallerinaModel.Listener.HTTPListener;
 import common.BallerinaModel.ModuleTypeDef;
 import common.BallerinaModel.Service;
 import common.BallerinaModel.TextDocument;
+import common.BallerinaModel.TypeDesc;
+import common.BallerinaModel.TypeDesc.BallerinaType;
+import common.BallerinaModel.TypeDesc.RecordTypeDesc;
+import common.BallerinaModel.TypeDesc.RecordTypeDesc.RecordField;
+import common.BallerinaModel.TypeDesc.UnionTypeDesc;
 import synapse.converter.BIRConverter.APIConverter;
+import synapse.converter.ConversionContext.PropertyInfo;
 import synapse.model.DependencyGraph;
 import synapse.model.DependencyGraph.ArtifactNode;
 import synapse.model.DependencyResolver;
@@ -70,6 +76,8 @@ public final class SynapseConverter {
     private static final String DEFAULT_HOST = "0.0.0.0";
     private static final String DEFAULT_ORG = "wso2";
     private static final String DEFAULT_PACKAGE = "synapse";
+    private static final String CONTEXT_TYPE = "Context";
+    private static final String DEFAULT_SCOPE = "default";
 
     private static final Logger LOG = Logger.getLogger(SynapseConverter.class.getName());
 
@@ -144,8 +152,11 @@ public final class SynapseConverter {
                 writeArtifacts(targetDir, context, writtenImports);
                 context.clearArtifactOutput();
             }
-            if (dependencyGraph.sortedNodes().isEmpty()) {
-                // No convertible artifacts (e.g. a <proxy>): still emit the base package skeleton.
+            addContextRecord(context);
+            if (dependencyGraph.sortedNodes().isEmpty() || !context.records().isEmpty()) {
+                // Emit the base package skeleton when there were no convertible artifacts (e.g. a
+                // <proxy>), and flush the Context record to types.bal once every artifact's default
+                // properties have been collected.
                 writeArtifacts(targetDir, context, writtenImports);
             }
         } catch (IOException e) {
@@ -177,6 +188,26 @@ public final class SynapseConverter {
             throw new UnsupportedOperationException("No root converter for Synapse node kind: " + node.kind());
         }
         converter.convert(node, context);
+    }
+
+    private static void addContextRecord(ConversionContext context) {
+        List<RecordField> fields = new ArrayList<>();
+        for (Map.Entry<String, PropertyInfo> property : context.properties().entrySet()) {
+            if (DEFAULT_SCOPE.equals(property.getValue().scope())) {
+                fields.add(new RecordField(property.getKey(), fieldType(property.getValue().types()), true));
+            }
+        }
+        if (fields.isEmpty()) {
+            return;
+        }
+        context.addRecord(new ModuleTypeDef(CONTEXT_TYPE, RecordTypeDesc.closedRecord(fields)));
+    }
+
+    private static TypeDesc fieldType(Set<String> types) {
+        if (types.size() == 1) {
+            return new BallerinaType(types.iterator().next());
+        }
+        return new UnionTypeDesc(types.stream().map(BallerinaType::new).toList());
     }
 
     private static void writeArtifacts(Path targetDir, ConversionContext context,

--- a/synapse/src/main/java/synapse/converter/SynapseConverter.java
+++ b/synapse/src/main/java/synapse/converter/SynapseConverter.java
@@ -30,6 +30,7 @@ import common.BallerinaModel.TypeDesc.BallerinaType;
 import common.BallerinaModel.TypeDesc.RecordTypeDesc;
 import common.BallerinaModel.TypeDesc.RecordTypeDesc.RecordField;
 import common.BallerinaModel.TypeDesc.UnionTypeDesc;
+import org.jetbrains.annotations.NotNull;
 import synapse.converter.BIRConverter.APIConverter;
 import synapse.converter.ConversionContext.PropertyInfo;
 import synapse.model.DependencyGraph;
@@ -78,6 +79,7 @@ public final class SynapseConverter {
     private static final String DEFAULT_PACKAGE = "synapse";
     private static final String CONTEXT_TYPE = "Context";
     private static final String DEFAULT_SCOPE = "default";
+    private static final String SYNAPSE_SCOPE = "synapse";
 
     private static final Logger LOG = Logger.getLogger(SynapseConverter.class.getName());
 
@@ -193,7 +195,8 @@ public final class SynapseConverter {
     private static void addContextRecord(ConversionContext context) {
         List<RecordField> fields = new ArrayList<>();
         for (Map.Entry<String, PropertyInfo> property : context.properties().entrySet()) {
-            if (DEFAULT_SCOPE.equals(property.getValue().scope())) {
+            String scope = property.getValue().scope();
+            if (DEFAULT_SCOPE.equals(scope) || SYNAPSE_SCOPE.equals(scope)) {
                 fields.add(new RecordField(property.getKey(), fieldType(property.getValue().types()), true));
             }
         }
@@ -203,6 +206,7 @@ public final class SynapseConverter {
         context.addRecord(new ModuleTypeDef(CONTEXT_TYPE, RecordTypeDesc.closedRecord(fields)));
     }
 
+    @NotNull
     private static TypeDesc fieldType(Set<String> types) {
         if (types.size() == 1) {
             return new BallerinaType(types.iterator().next());

--- a/synapse/src/main/java/synapse/model/Synapse.java
+++ b/synapse/src/main/java/synapse/model/Synapse.java
@@ -73,12 +73,14 @@ public record Synapse() {
         }
     }
 
-    // <property name="..." scope="default|transport|axis2|axis2-client" type="string" value="..."/>
-    // -> sets a named property (of the given type and scope) to the given value.
-    public record Property(Kind kind, String name, String type, String scope, String value)
+    // <property name="..." scope="default|transport|axis2|axis2-client" type="string" value="..."
+    //           action="set|remove"/>
+    // -> action "set" (the default) sets a named property (of the given type and scope) to the given
+    //    value; action "remove" clears it.
+    public record Property(Kind kind, String name, String type, String scope, String value, String action)
             implements SynapseNode {
-        public Property(String name, String type, String scope, String value) {
-            this(Kind.PROPERTY, name, type, scope, value);
+        public Property(String name, String type, String scope, String value, String action) {
+            this(Kind.PROPERTY, name, type, scope, value, action);
         }
     }
 

--- a/synapse/src/main/java/synapse/reader/SynapseModelGenerator.java
+++ b/synapse/src/main/java/synapse/reader/SynapseModelGenerator.java
@@ -17,6 +17,7 @@
  */
 package synapse.reader;
 
+import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -167,6 +168,7 @@ public class SynapseModelGenerator {
         return mediators;
     }
 
+    @NotNull
     private static Property readProperty(Element element) {
         String name = element.getAttribute("name");
 

--- a/synapse/src/main/java/synapse/reader/SynapseModelGenerator.java
+++ b/synapse/src/main/java/synapse/reader/SynapseModelGenerator.java
@@ -46,6 +46,7 @@ public class SynapseModelGenerator {
 
     private static final String DEFAULT_PROPERTY_TYPE = "string";
     private static final String DEFAULT_PROPERTY_SCOPE = "default";
+    private static final String DEFAULT_PROPERTY_ACTION = "set";
 
     public static List<SynapseNode> generateModel(Element rootElement) {
         List<SynapseNode> nodes = new ArrayList<>();
@@ -180,7 +181,13 @@ public class SynapseModelGenerator {
         }
 
         String value = element.getAttribute("value");
-        return new Property(name, type, scope, value);
+
+        String action = element.getAttribute("action");
+        if (action.isEmpty()) {
+            action = DEFAULT_PROPERTY_ACTION;
+        }
+
+        return new Property(name, type, scope, value, action);
     }
 
     private static PayloadFactory readPayloadFactory(Element element) {


### PR DESCRIPTION
## Purpose

Fixes [1939](https://github.com/wso2-enterprise/integration-engineering/issues/1939)

## Approach
  1. A single request-scoped Context record
  - Every default-scope property becomes an optional field of one project-wide Context record generated in types.bal, e.g. public type Context record {| string str?; int count?; |};.
  - A <property> mediator is translated to a field assignment on a ctx value: <property name="str" .../> → ctx.str = "...";.
  - ctx is initialized once at the start of an API resource (Context ctx = {};) and lives until the resource responds.

  2. Threading ctx through the call graph
  - Sequences become functions. A function that touches default properties (directly, or transitively via a sequence it calls) takes a Context ctx parameter it mutates in place; call sites pass ctx.
  - This mirrors the existing http:Response handling: ScopeContext tracks whether ctx is available (declared in a resource vs. received as a parameter), and SequenceMetadata.usesContext propagates the
  "needs ctx" fact up the graph.
  - Because artifacts are converted leaf-first, a callee's metadata is already known at each call site — no separate pass needed. A resource that calls foo which calls bar gets Context ctx = {}; foo(ctx);,
  with foo/bar typed foo(Context ctx) even if they only forward it.
  
  3. Property registry → record generation
  - Default-scope properties are collected into a project-wide registry on ConversionContext as they're converted (surviving per-artifact output flushing).
  - After all artifacts are converted, the Context record is built from the registry and written to types.bal once. Fields are optional so Context ctx = {}; and ctx.x = ... both type-check.

  4. Type conflicts → union fields
  - The registry accumulates the set of types seen per property name. If the same name is declared with different types across the project, the field becomes a union (e.g. string|int prop1?;), so all
  assignments remain valid rather than silently mismatching. Single-type names stay simple (string prop1?;).
  
  5. action="set|remove"
  - set (default) — assigns the value and registers the field.
  - remove — emits ctx.<name> = (); (clearing the field) and does not register it, since the field is contributed by the property's set. Assigning () to an optional field is valid Ballerina (it removes the
  field).

  Scope / limitations

  - Only the default scope maps to Context. transport/axis2 scopes remain response header/status assignments as before. Scope is retained per property in the registry to accommodate future scopes.
  - expression-valued properties are out of scope; value is used as the Ballerina expression literal.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.
